### PR TITLE
dont assume segment operations exists

### DIFF
--- a/azure/components/network/state.ftl
+++ b/azure/components/network/state.ftl
@@ -10,9 +10,13 @@
   [#local nsgId = formatDependentNetworkSecurityGroupId(vnetId)]
   [#local nsgName = formatName(vnetName, AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE)]
 
-  [#local nsgFlowLogEnabled = environmentObject.Operations.FlowLogs.Enabled!
-    segmentObject.Operations.FlowLogs.Enabled!
-    solution.Logging.EnableFlowLogs ]
+  [#local nsgFlowLogEnabled = isPresent(segmentObject.Operations)?then(
+      isPresent(environmentObject.Operations.FlowLogs) || 
+      isPresent(segmentObject.Operations.FlowLogs) ||
+      solution.Logging.EnableFlowLogs,
+      isPresent(environmentObject.Operations.FlowLogs) || 
+      solution.Logging.EnableFlowLogs
+  )]
 
   [#local networkCIDR = (network.CIDR)?has_content?then(
     network.CIDR.Address + "/" + network.CIDR.Mask,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Azure provider PR that addresses same as hamlet-io/engine-plugin-aws#25 - don't assume that this object exists.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug preventing network component or anything that links to it from generating as it doesn't exist by default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
