### PR TITLE
Refactor - VM Image Profiles + Move to Plugin

### DIFF
--- a/azure/components/bastion/setup.ftl
+++ b/azure/components/bastion/setup.ftl
@@ -142,6 +142,7 @@
   )]
 
   [#local vmssVMNetworkProfile = getVirtualMachineNetworkProfile([vmssVMNICConfig])]
+  [#local vmssVMSkuProfile = getSkuProfile(occurrence, core.Type)]
 
   [#local vmssVMProfile = getVirtualMachineProfile(
     core.Type,
@@ -149,7 +150,7 @@
     "Standard_LRS",
     vmssVMImageProfile.Publisher,
     vmssVMImageProfile.Offering,
-    vmssVMImageProfile.SKU,
+    vmssVMImageProfile.Image,
     vmssVMNetworkProfile,
     vmssVMOSConfig
   )]
@@ -159,9 +160,9 @@
     identity={"type": "SystemAssigned"}
     name=scaleSet.Name
     location=regionId
-    skuName=vmssProcessor
-    skuTier=vmssProcessorTier
-    skuCapacity=autoScaleConfig.MinUpdateInstances
+    skuName=vmssVMSkuProfile.Name
+    skuTier=vmssVMSkuProfile.Tier
+    skuCapacity=vmssVMSkuProfile.Capacity
     vmProfile=vmssVMProfile
     dependsOn=
       [

--- a/azure/components/bastion/setup.ftl
+++ b/azure/components/bastion/setup.ftl
@@ -91,7 +91,7 @@
   [#local vmssProcessorType = vmssProcessorProfile[core.Type]]
   [#local vmssProcessor = vmssProcessorType.Processor]
   [#local vmssProcessorTier = vmssProcessor?split("_")[0]]
-  [#local vmssVMImageProfile = vmImageProfiles[BASTION_COMPONENT_TYPE]]
+  [#local vmssVMImageProfile = getVMImageProfile(occurrence, core.Type)]
   [#local vmssVMAdminName = BASTION_COMPONENT_TYPE]
 
   [#if deploymentSubsetRequired("parameters", true)]

--- a/azure/inputsources/shared/masterdata.ftl
+++ b/azure/inputsources/shared/masterdata.ftl
@@ -1153,10 +1153,17 @@
       },
       "LogFilters": {},
       "VMImageProfiles" : {
-        "bastion" : {
-          "Publisher" : "Canonical",
-          "Offering" : "UbuntuServer",
-          "SKU" : "18.04-LTS"
+        "default" : {
+          "bastion" : {
+            "Publisher" : "Canonical",
+            "Offering" : "UbuntuServer",
+            "SKU" : "18.04-LTS"
+          },
+          "computecluster" : {
+            "Publisher" : "Canonical",
+            "Offering" : "UbuntuServer",
+            "SKU" : "18.04-LTS"
+          }
         }
       },
       "NetworkEndpointGroups": {

--- a/azure/inputsources/shared/masterdata.ftl
+++ b/azure/inputsources/shared/masterdata.ftl
@@ -1157,12 +1157,12 @@
           "bastion" : {
             "Publisher" : "Canonical",
             "Offering" : "UbuntuServer",
-            "SKU" : "18.04-LTS"
+            "Image" : "18.04-LTS"
           },
           "computecluster" : {
             "Publisher" : "Canonical",
             "Offering" : "UbuntuServer",
-            "SKU" : "18.04-LTS"
+            "Image" : "18.04-LTS"
           }
         }
       },
@@ -1211,6 +1211,11 @@
         "default" : {
           "apigateway" : {
             "Name" : "Developer"
+          },
+          "bastion" : {
+            "Name" : "Standard_B1s",
+            "Tier" : "Standard",
+            "Capacity" : 0
           }
         }
       },

--- a/azure/references/SkuProfile/id.ftl
+++ b/azure/references/SkuProfile/id.ftl
@@ -123,17 +123,3 @@
         }
     ]
 /]
-
-[#function getSkuProfile occurrence type extensions... ]	
-    [#local tc = formatComponentShortName(	
-                    occurrence.Core.Tier,	
-                    occurrence.Core.Component,	
-                    extensions)]	
-    [#local defaultProfile = "default"]	
-    [#if (skuProfiles[defaultProfile][tc])??]	
-        [#return skuProfiles[defaultProfile][tc]]	
-    [/#if]	
-    [#if (skuProfiles[defaultProfile][type])??]	
-        [#return skuProfiles[defaultProfile][type]]	
-    [/#if]	
-[/#function]

--- a/azure/references/SkuProfile/id.ftl
+++ b/azure/references/SkuProfile/id.ftl
@@ -110,14 +110,16 @@
             "Names" : "bastion",
             "Children" : [
                 {
-                    "Names" : "Profiles",
-                    "Children" :
-                        [
-                            {
-                                "Names" : "Processor",
-                                "Type" : STRING_TYPE
-                            }
-                        ]
+                    "Names" : "Name",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "Tier",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "Capacity",
+                    "Type" : NUMBER_TYPE
                 }
             ]
         }

--- a/azure/references/SkuProfile/reference.ftl
+++ b/azure/references/SkuProfile/reference.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[@addReferenceData type=SKU_PROFILE_REFERENCE_TYPE base=blueprintObject /]
+[#assign skuProfiles = getReferenceData(SKU_PROFILE_REFERENCE_TYPE)]
+
+[#function getSkuProfile occurrence type extensions... ]	
+    [#local tc = formatComponentShortName(	
+                    occurrence.Core.Tier,	
+                    occurrence.Core.Component,	
+                    extensions)]	
+    [#local defaultProfile = "default"]	
+    [#if (skuProfiles[defaultProfile][tc])??]	
+        [#return skuProfiles[defaultProfile][tc]]	
+    [/#if]	
+    [#if (skuProfiles[defaultProfile][type])??]	
+        [#return skuProfiles[defaultProfile][type]]	
+    [/#if]	
+[/#function]

--- a/azure/references/VMImageProfile/id.ftl
+++ b/azure/references/VMImageProfile/id.ftl
@@ -1,0 +1,40 @@
+[#ftl]
+
+[@addReference 
+    type=VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE
+    pluralType="VMImageProfiles"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "A virtual machine operating system configuration" 
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "*",
+            "Description" : "The component type that the VMImage configuration belongs to.",
+            "Children" : [
+                {
+                    "Names" : "Publisher",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "Offering",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "SKU",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "LicenseType",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : false
+                }
+            ]
+        }
+    ]
+/]

--- a/azure/references/VMImageProfile/id.ftl
+++ b/azure/references/VMImageProfile/id.ftl
@@ -25,7 +25,7 @@
                     "Mandatory" : true
                 },
                 {
-                    "Names" : "SKU",
+                    "Names" : "Image",
                     "Type" : STRING_TYPE,
                     "Mandatory" : true
                 },

--- a/azure/references/VMImageProfile/reference.ftl
+++ b/azure/references/VMImageProfile/reference.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[@addReferenceData type=VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE base=blueprintObject /]
+[#assign vmImageProfiles = getReferenceData(VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE) ]
+
+[#function getVMImageProfile occurrence type extensions... ]	
+    [#local tc = formatComponentShortName(	
+                    occurrence.Core.Tier,	
+                    occurrence.Core.Component,	
+                    extensions)]	
+    [#local defaultProfile = "default"]	
+    [#if (vmImageProfiles[defaultProfile][tc])??]	
+        [#return vmImageProfiles[defaultProfile][tc]]	
+    [/#if]	
+    [#if (vmImageProfiles[defaultProfile][type])??]	
+        [#return vmImageProfiles[defaultProfile][type]]	
+    [/#if]	
+[/#function]

--- a/azure/references/reference.ftl
+++ b/azure/references/reference.ftl
@@ -1,3 +1,4 @@
 [#ftl]
 
 [#assign SKU_PROFILE_REFERENCE_TYPE = "SkuProfile"]
+[#assign VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE = "VMImageProfile"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Moves the VMImageProfiles reference data into azure plugin provider.
- Refactors structure into correct alignment with other profile reference data types.
- Refactors "bastion" component to make use of new structure.
- Added some missing pieces for getSkuProfiles that I appear to have neglected to include in previous PR's but are definitely required to work.
- Split content between two files per reference type for clarity.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#66 will require VM Images, and #129 established working correct structure of reference data in plugins.
The move from the shared provider to the plugin was due to it being previously introduced at a time that reference data wasn't being dynamically loaded by plugins, which is no longer the case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- skuProfiles has previously been tested - not sure why it didn't get included in my previous PR's but its existing content that has been tested.
- VMImageProfiles has been tested by locally generating a "bastion" deployment-unit under the new reference data structure.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] Create a corresponding PR to remove VMImageProfiles from shared provider.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
