### PR TITLE
Feature - Userpool Output Client + Object Ids

### DIFF
--- a/azure/components/apigateway/state.ftl
+++ b/azure/components/apigateway/state.ftl
@@ -139,7 +139,7 @@
                                                 "Name" : identityproviderName,
                                                 "Type" : AZURE_API_MANAGEMENT_SERVICE_IDENTITY_PROVIDER,
                                                 "Reference" : getReference(identityproviderId, identityproviderName),
-                                                "ObjectId" : subAttributes["CLIENT"]!getExistingReference(subCore.Id),
+                                                "ObjectId" : subAttributes["CLIENT_OBJECT_ID"]!getExistingReference(subCore.Id),
                                                 "SecretId" : identityProviderSecretId
                                             }
                                         }

--- a/azure/components/userpool/setup.ftl
+++ b/azure/components/userpool/setup.ftl
@@ -126,7 +126,8 @@
             [
                 "   create|update)",   
                 "       az ad app create " + args?join(" ") + " > $tmp/registration.json",
-                "       objectId=$(runJQ -r '.objectId' < $tmp/registration.json)"
+                "       objectId=$(runJQ -r '.objectId' < $tmp/registration.json)",
+                "       clientId=$(runJQ -r '.appId' < $tmp/registration.json)"
             ] +
             generateSecret?then(
                 [
@@ -141,7 +142,8 @@
             pseudoArmStackOutputScript(
                 "Client Registration",
                 {
-                    client.Id : "$\{objectId}"
+                    client.Id : "$\{objectId}",
+                    client.ClientAppId : "$\{clientId}"
                 },
                 "client"
             ) +

--- a/azure/components/userpool/state.ftl
+++ b/azure/components/userpool/state.ftl
@@ -25,6 +25,8 @@
     [#local id = formatResourceId(AZURE_APPLICATION_REGISTRATION_RESOURCE_TYPE, core.Name)]
     [#local name = formatName(core.Name)]
 
+    [#local clientAppId = formatId(id, "appid")]
+
     [#local parentAttributes = parent.State.Attributes]
 
     [#assign componentState=
@@ -32,13 +34,15 @@
             "Resources" : {
                 "client" : {
                     "Id" : id,
+                    "ClientAppId" : clientAppId,
                     "Name" : name,
                     "Type" : AZURE_APPLICATION_REGISTRATION_RESOURCE_TYPE,
                     "Reference" : getReference(id, name)
                 }
             },
             "Attributes" : parentAttributes + {
-                "CLIENT" : getExistingReference(id)
+                "CLIENT_APP_ID" : getExistingReference(clientAppId),
+                "CLIENT_OBJECT_ID" : getExistingReference(id)
             },
             "Roles" : {
                 "Inbound" : {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Amends the Userpool outputs to include the ClientId and the ObjectId, which are used by different hamlet components.
Includes a refactor of the APIGateway reference to the ObjectId to make it clearer which attribute is which.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An application registration - the result of a Userpool deployment unit using the AAD engine type  in Azure - should output both the ClientId (also known as App Id) which is required by application deployments as well as the ObjectId, which is how an API Gateway references the registration. Currently its only outputting the ObjectId.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
