### PR TITLE
Feature - SPA Auth Mode and Quiet

### DIFF
--- a/azure/utility.sh
+++ b/azure/utility.sh
@@ -80,7 +80,7 @@ function az_sync_with_blob(){
     if [[ -f "${file}" ]]; then
       case "$(fileExtension "${file}")" in
         zip)
-          unzip -DD "${file}" -d "${tmp_dir}"
+          unzip -DD -q "${file}" -d "${tmp_dir}"
           ;;
         *)
           cp "${file}" "${tmp_dir}"
@@ -90,10 +90,16 @@ function az_sync_with_blob(){
   done
 
   args=(
+    "auth-mode login"
     "account-name ${storageAccountName}"
     "container ${containerName}"
     "source ${tmp_dir}"
   )
+
+  # -- Only show errors unless debugging --
+  if [[ -z "${GENERATION_LOG_LEVEL}" ]]; then
+    args=("${args[@]}" "only-show-errors" )
+  fi
 
   if [[ -n "${destinationSuffix}" ]]; then
     args=("${args[@]}" "destination ${destinationSuffix}")
@@ -108,9 +114,15 @@ function az_delete_blob_dir(){
   local pattern="$1"; shift
 
   args=(
+    "auth-mode login"
     "account-name ${storageAccountName}"
     "source ${sourcePath}"
   )
+
+  # -- Only show errors unless debugging --
+  if [[ -z "${GENERATION_LOG_LEVEL}" ]]; then
+    args=("${args[@]}" "only-show-errors" )
+  fi
 
   if [[ -n "${pattern}" ]]; then
     args=("${args[@]}" "pattern ${pattern}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates utilities.sh to:
- specify an auth-mode for storage account sync functions
- update several functions with quieter modes that will still show errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
General noise reduction in output during deployment. An auth-mode of login will use the currently logged in account for the file sync, which is already a requirement for deployment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
