### PR TITLE
fixed publisher/type/handler for extension config

### DIFF
--- a/azure/components/computecluster/setup.ftl
+++ b/azure/components/computecluster/setup.ftl
@@ -299,6 +299,7 @@
     [/#if]
     [#local indices = indices?sort]
     
+    [#local extensionScriptConfig = {}]
     [#list indices as index]
 
         [#local extConfig = getBootstrapByIndex(index)]
@@ -315,6 +316,10 @@
             [#local extProtectedSettings += {"script" : extConfig.InitScript}]
         [/#if]
 
+        [#if (extConfig.Publisher)?has_content || (extConfig.Type)?has_content]
+            [#local extensionScriptConfig = 
+                mergeObjects(extensionScriptConfig, extConfig)]
+        [/#if]
     [/#list]
 
     [#local extProtectedSettings = mergeObjects(
@@ -326,12 +331,13 @@
     [@createVMScaleSetExtension
         id=extension.Id
         name=extension.Name
-        publisher=extConfig.Publisher!""
-        type=extConfig.Type.Name!""
-        typeHandlerVersion=extConfig.Type.HandlerVersion!""
-        autoUpgradeMinorVersion=extConfig.AutoUpgradeOnMinorVersion
+        publisher=extensionScriptConfig.Publisher
+        type=extensionScriptConfig.Type.Name
+        typeHandlerVersion=extensionScriptConfig.Type.HandlerVersion
+        autoUpgradeMinorVersion=extensionScriptConfig.AutoUpgradeOnMinorVersion!true
         protectedSettings=extProtectedSettings
         provisionAfterExtensions=provisionAfterExtensions
+        dependsOn=[scaleSet.Reference]
     /]
 
 [/#macro]

--- a/azure/components/computecluster/setup.ftl
+++ b/azure/components/computecluster/setup.ftl
@@ -331,10 +331,7 @@
     [@createVMScaleSetExtension
         id=extension.Id
         name=extension.Name
-        publisher=extensionScriptConfig.Publisher
-        type=extensionScriptConfig.Type.Name
-        typeHandlerVersion=extensionScriptConfig.Type.HandlerVersion
-        autoUpgradeMinorVersion=extensionScriptConfig.AutoUpgradeOnMinorVersion!true
+        scriptConfig=extensionScriptConfig
         protectedSettings=extProtectedSettings
         provisionAfterExtensions=provisionAfterExtensions
         dependsOn=[scaleSet.Reference]

--- a/azure/services/microsoft.compute/resource.ftl
+++ b/azure/services/microsoft.compute/resource.ftl
@@ -184,17 +184,14 @@
 [#macro createVMScaleSetExtension
   id
   name
-  publisher=""
-  type=""
-  typeHandlerVersion=""
-  autoUpgradeMinorVersion=false
+  scriptConfig
   settings={}
   protectedSettings={}
   provisionAfterExtensions=[]
   dependsOn=[]]
 
-  [#-- Settings should be listed even when empty. --]
 
+  [#-- Settings should be listed even when empty. --]
   [@armResource
     id=id
     name=name
@@ -203,10 +200,10 @@
     properties={
       "settings" : settings
     } +
-      attributeIfContent("publisher", publisher) +
-      attributeIfContent("type", type) +
-      attributeIfContent("typeHandlerVersion", typeHandlerVersion) +
-      attributeIfContent("autoUpgradeMinorVersion", autoUpgradeMinorVersion) +
+      attributeIfContent("publisher", scriptConfig.Publisher) +
+      attributeIfContent("type", scriptConfig.Type.Name) +
+      attributeIfContent("typeHandlerVersion", scriptConfig.Type.HandlerVersion) +
+      attributeIfTrue("autoUpgradeMinorVersion", scriptConfig.AutoUpgradeOnMinorVersion!false, scriptConfig.AutoUpgradeOnMinorVersion) +
       attributeIfContent("protectedSettings", protectedSettings) +
       attributeIfContent("provisionAfterExtensions", provisionAfterExtensions)
   /]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Corrects a problem gathering ScaleSet Extension configuration when the last Bootstrap Profile loaded doesn't have a publisher/type/handler configured.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug was exposed after adding a new Bootstrap which did not have these attributes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and subsequent deployment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
