### PR TITLE
Fix - ComputeCluster Timestamp Bug

### DIFF
--- a/azure/components/computecluster/setup.ftl
+++ b/azure/components/computecluster/setup.ftl
@@ -332,16 +332,13 @@
         )
     /]
 
-    [#local timestamp = datetimeAsString(.now)?replace("[^\\d]", '', 'r')]
     [@addParametersToDefaultJsonOutput id="container" parameter=stageStorage.Container /]
     [@addParametersToDefaultJsonOutput id="blob" parameter=stageStorage.BlobPath /]
     [@addParametersToDefaultJsonOutput id="file" parameter=stageStorage.BlobName /]
-    [@addParametersToDefaultJsonOutput id="timestamp" parameter=timestamp /]
     [@armParameter name="storage" /]
     [@armParameter name="container" /]
     [@armParameter name="blob" /]
     [@armParameter name="file" /]
-    [@armParameter name="timestamp" /]
 
     [#-- Construct Index List & Concatenate Exec commands --]
     [#local indices = []]

--- a/azure/services/microsoft.compute/resource.ftl
+++ b/azure/services/microsoft.compute/resource.ftl
@@ -187,18 +187,22 @@
   scriptConfig
   settings={}
   protectedSettings={}
+  addTimestamp=true
   provisionAfterExtensions=[]
   dependsOn=[]]
 
+  [#-- Settings should be listed even when empty.                            --]
+  [#-- addTimestamp will force a deployment even when template is unchanged. --]
+  [#local timestamp = datetimeAsString(.now)?replace("[^\\d]", '', 'r')]
 
-  [#-- Settings should be listed even when empty. --]
   [@armResource
     id=id
     name=name
     profile=AZURE_VIRTUALMACHINE_SCALESET_EXTENSION_RESOURCE_TYPE
     dependsOn=dependsOn
     properties={
-      "settings" : settings
+      "settings" : settings +
+        attributeIfTrue("timestamp", addTimestamp, timestamp?number)
     } +
       attributeIfContent("publisher", scriptConfig.Publisher) +
       attributeIfContent("type", scriptConfig.Type.Name) +


### PR DESCRIPTION
Timestamp must be passed as an int, to later re-read it and compare with current time.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pass the timestamp value as an integer to the template. 
- Includes a refactor to move the timestamp generation and value into a bool on the resource to ensure its always passed correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Whilst deploying successfully initially, passing the timestamp as a string prevents Azure from comparing the string with a timestamp in another deployment (it attempts to compare integers to see if one is later than the other). This prevents most changes to the resource from being successful even when unrelated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and deployment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
