### PR TITLE
Fix - ComputeCluster InitScript

### DIFF
--- a/azure/components/computecluster/setup.ftl
+++ b/azure/components/computecluster/setup.ftl
@@ -395,10 +395,6 @@
             [/#list]
         [/#if]
 
-        [#if extConfig.InitScript??]
-            [#local extProtectedSettings += {"script" : extConfig.InitScript}]
-        [/#if]
-
         [#local extensionScriptConfig = 
             mergeObjects(extensionScriptConfig, extConfig)]
 

--- a/azure/inputsources/shared/masterdata.ftl
+++ b/azure/inputsources/shared/masterdata.ftl
@@ -1170,7 +1170,7 @@
           "ProtectedSettings" : {
             "makeBase64" : {
               "Key" : "commandToExecute",
-              "Value" : "cat ./init.sh | base64 -w0 > ./init-encoded.sh"
+              "Value" : "cat ./init.sh | base64 -w0 > ./init-encoded.sh'"
             }
           }
         },
@@ -1181,7 +1181,12 @@
             "Name" : "CustomScript",
             "HandlerVersion" : "2.1"
           },
-          "InitScript" : "./init-encoded.sh"
+          "ProtectedSettings" : {
+            "initEncoded" : {
+              "Key" : "commandToExecute",
+              "Value" : "./init-encoded.sh"
+            }
+          }
         },
         "timestamp" : {
           "Index" : 1000,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Merged the "Script" and "CommandToExecute" properties of the bootstrap process into the latter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Turns out you can't use both together and there will usually be a need to perform at least the base64 encoding on a script before executing it (a requirement for the "script" parameter". Deployment was always successful together but issues would appear later when trying to modify the resource.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and deployment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
