### PR TITLE
refactor(gateway): rename vpcendpoint to privateservice

### DIFF
--- a/azure/components/gateway/setup.ftl
+++ b/azure/components/gateway/setup.ftl
@@ -80,6 +80,7 @@
 
     [#switch gwSolution.Engine]
       [#case "vpcendpoint"]
+      [#case "privateservice"]
         [#local networkEndpoints = getNetworkEndpoints(solution.NetworkEndpointGroups, "a", region)]
         [#list networkEndpoints as id, networkEndpoint]
           [#if networkEndpoint.Type == "PrivateLink"]

--- a/azure/components/gateway/state.ftl
+++ b/azure/components/gateway/state.ftl
@@ -5,9 +5,9 @@
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
   [#local engine = solution.Engine ]
- 
-  [#if engine == "vpcendpoint"]
-    [#-- 
+
+  [#if engine == "vpcendpoint" || engine == "privateservice" ]
+    [#--
       A private DNS Zone is required so we can force routing to the endpoint to remain within the
       VNet. If we don't then default routing may send traffic via the Internet.
     --]
@@ -33,7 +33,7 @@
         }
       }
     ]
-      
+
   [#else]
     [@fatal
       message="Unknown Engine Type"
@@ -53,10 +53,10 @@
 
   [#local resources = {}]
 
-  [#if engine == "vpcendpoint"]
+  [#if engine == "vpcendpoint" || engine == "privateservice" ]
 
     [#local networkEndpoints = getNetworkEndpoints(solution.NetworkEndpointGroups, "a", region)]
-      
+
     [#list networkEndpoints as id, networkEndpoint]
 
       [#switch networkEndpoint.Type]
@@ -65,7 +65,7 @@
         [#case "PrivateLink"]
           [#-- TODO(rossmurr4y): impliment Azure Private Links --]
           [#break]
-      [/#switch] 
+      [/#switch]
 
     [/#list]
 

--- a/azure/components/network/setup.ftl
+++ b/azure/components/network/setup.ftl
@@ -170,7 +170,7 @@
 
             [#switch linkTarget.Core.Type]
               [#case NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE]
-                [#if linkTarget.State.Attributes.Engine = "vpcendpoint"]
+                [#if linkTarget.State.Attributes.Engine = "vpcendpoint" || linkTarget.State.Attributes.Engine = "privateservice" ]
                   [#local linkNetworkEndpointGroups = linkTargetConfiguration.Solution.NetworkEndpointGroups]
                   [#list linkNetworkEndpointGroups as group]
                     [#if !networkEndpointGroups?seq_contains(group)]

--- a/azure/inputsources/shared/masterdata.ftl
+++ b/azure/inputsources/shared/masterdata.ftl
@@ -952,7 +952,7 @@
                 "vpcendpoint"
               ],
               "gateway": {
-                "Engine": "vpcendpoint",
+                "Engine": "privateservice",
                 "Destinations": {
                   "default": {
                     "NetworkEndpointGroups": [


### PR DESCRIPTION
# Description
Implements the rename of vpcendpoint to private service as part of https://github.com/hamlet-io/engine/pull/1335 


## Motivation and Context
Vendor agnostic naming of the gateway engine type

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
