### PR TITLE
refactor: remove console only from bastion masterdata

### DIFF
--- a/azure/inputsources/shared/masterdata.ftl
+++ b/azure/inputsources/shared/masterdata.ftl
@@ -1329,7 +1329,6 @@
           "Active": false,
           "IPAddressGroups": []
         },
-        "ConsoleOnly": false,
         "S3": {
           "IncludeTenant": false
         },


### PR DESCRIPTION
## Description
Minor refactor to remove the console only option from the segment/bastion masterdata. This option is not longer supported and shouldn't be used

## Motivation and Context
This should be more a bastion component specific option rather than a master data controlled thing 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
