### PR TITLE
Feat global resource config

### DIFF
--- a/azure/deploymentframeworks/arm/output.ftl
+++ b/azure/deploymentframeworks/arm/output.ftl
@@ -147,6 +147,7 @@
     parentNames=[]]
 
     [#local resourceProfile = getAzureResourceProfile(profile)]
+    [#local resourceLocation = resourceProfile.global?then("global", location)]
 
     [#if !(resourceProfile.type == "pseudo")]
         [@addToJsonOutput
@@ -159,7 +160,7 @@
                     "properties": properties
                 } +
                 attributeIfContent("identity", identity) +
-                attributeIfContent("location", location) +
+                attributeIfContent("location", resourceLocation) +
                 attributeIfContent("dependsOn", dependsOn) +
                 attributeIfContent("tags", tags) +
                 attributeIfContent("comments", comments) +

--- a/azure/services/microsoft.apimanagement/resource.ftl
+++ b/azure/services/microsoft.apimanagement/resource.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#assign apiManagementResourceprofiles = 
+[#local apiManagementResourceprofiles = 
     {
         AZURE_API_MANAGEMENT_SERVICE : {
             "apiVersion" : "2019-01-01",
@@ -388,7 +388,6 @@
     value=""
     format="openapi"
     wsdlServiceName=""
-    wsdlEndpointName=""
     apiType=""
     resources=[]
     dependsOn=[]]

--- a/azure/services/microsoft.apimanagement/resource.ftl
+++ b/azure/services/microsoft.apimanagement/resource.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#local apiManagementResourceprofiles = 
+[#assign apiManagementResourceprofiles = 
     {
         AZURE_API_MANAGEMENT_SERVICE : {
             "apiVersion" : "2019-01-01",
@@ -388,6 +388,7 @@
     value=""
     format="openapi"
     wsdlServiceName=""
+    wsdlEndpointName=""
     apiType=""
     resources=[]
     dependsOn=[]]

--- a/azure/services/microsoft.network.frontdoor/resource.ftl
+++ b/azure/services/microsoft.network.frontdoor/resource.ftl
@@ -12,7 +12,8 @@
         REFERENCE_ATTRIBUTE_TYPE : {
           "Property" : "id"
         }
-      }
+      },
+      "global" : true
     }
 /]
 

--- a/azure/services/resource.ftl
+++ b/azure/services/resource.ftl
@@ -33,8 +33,13 @@
             },
             {
                 "Names" : "outputMappings",
-                "type" : OBJECT_TYPE,
+                "Type" : OBJECT_TYPE,
                 "Mandatory" : true
+            },
+            {
+                "Names" : "global",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
             }
         ]
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update Resource Profiles to include a setting for Global resources.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Global resources should use the "global" region, overriding any other region defined elsewhere.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation on the CDN Component - FrontDoor was thus assigned a location of "global" whilst other resources did not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
