### PR TITLE
fix(cdn): ensure frontdoor names are unique globally

### DIFF
--- a/azure/components/cdn/state.ftl
+++ b/azure/components/cdn/state.ftl
@@ -5,8 +5,11 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
+    [#local segmentSeedId = formatSegmentSeedId() ]
+    [#local segmentSeed = getExistingReference(segmentSeedId)]
+
     [#local frontDoorId = formatResourceId(AZURE_FRONTDOOR_RESOURCE_TYPE, core.Id)]
-    [#local frontDoorName = core.FullName]
+    [#local frontDoorName = formatName( core.FullName, segmentSeed) ]
     [#local wafPolicyId = formatDependentResourceId(AZURE_FRONTDOOR_WAF_POLICY_RESOURCE_TYPE, core.Id)]
     [#local wafPolicyName = formatAzureResourceName(
         formatName(AZURE_FRONTDOOR_WAF_POLICY_RESOURCE_TYPE, core.Tier, core.Component)


### PR DESCRIPTION
## Description
Use the segment seed to make frontdoor names globally unique

## Motivation and Context
The name of a frontdoor is used to determine the base DNS name for the frontdoor. As a result of this the name must be globally unique across all azure customers. 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
