### PR TITLE
fix(lambda): make lambda names globally unique

### DIFF
--- a/azure/components/lambda/state.ftl
+++ b/azure/components/lambda/state.ftl
@@ -30,7 +30,11 @@
 
     [#local core = occurrence.Core]
     [#local functionId = formatResourceId(AZURE_WEB_APP_RESOURCE_TYPE, core.Id)]
-    [#local functionName = core.ShortName]
+
+    [#local segmentSeedId = formatSegmentSeedId() ]
+    [#local segmentSeed = getExistingReference(segmentSeedId)]
+
+    [#local functionName = formatName(core.FullName, segmentSeed)]
 
     [#assign componentState =
         {


### PR DESCRIPTION
## Description
makes lambda function names globally unique

## Motivation and Context
Since webapps can create domain names using the name of the resource the name needs to be globally unique

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
