### PR TITLE
Fix - Lambda Naming

### DIFF
--- a/azure/components/lambda/state.ftl
+++ b/azure/components/lambda/state.ftl
@@ -30,7 +30,7 @@
 
     [#local core = occurrence.Core]
     [#local functionId = formatResourceId(AZURE_WEB_APP_RESOURCE_TYPE, core.Id)]
-    [#local functionName = core.ShortName]
+    [#local functionName = formatAzureResourceName(core.ShortFullName, AZURE_WEB_APP_RESOURCE_TYPE)]
 
     [#assign componentState =
         {

--- a/azure/services/microsoft.web/resource.ftl
+++ b/azure/services/microsoft.web/resource.ftl
@@ -22,6 +22,8 @@
         {
             "apiVersion": "2019-08-01",
             "type" : "Microsoft.Web/sites",
+            "conditions" : [ "max_length", "globally_unique"],
+            "max_name_length" : 60,
             "outputMappings" : {
                 REFERENCE_ATTRIBUTE_TYPE : {
                     "Property" : "id"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Update `Sites` resource (web app, including lambdas) to use the `formatAzureResourceName()` function.
- Include naming conditions on resource - `max_length` (60) and `globally_unique`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Both naming conventions are enforced by Azure on this resource.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Breaking Change : This will require re-deployment of Lambda's that have already been deployed.

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
