### PR TITLE
fix(storage): fix storage account naming

### DIFF
--- a/azure/components/baseline/state.ftl
+++ b/azure/components/baseline/state.ftl
@@ -3,7 +3,7 @@
 [#macro azure_baseline_arm_state occurrence parent={}]
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
-  
+
   [#local segmentSeedId = formatSegmentSeedId() ]
   [#if !(getExistingReference(segmentSeedId)?has_content) ]
     [#local segmentSeedValue = (commandLineOptions.Run.Id + accountObject.Seed)[0..(solution.Seed.Length - 1)]]
@@ -12,9 +12,9 @@
   [/#if]
 
   [#local storageAccountId = formatResourceId(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, core.Id)]
-  [#local storageAccountName = 
+  [#local storageAccountName =
     formatAzureResourceName(
-      formatName(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, segmentSeedValue),
+      formatName(core.ShortName, segmentSeedValue),
       AZURE_STORAGEACCOUNT_RESOURCE_TYPE
     )
   ]
@@ -34,7 +34,7 @@
     [#list settings?keys?filter(s -> s?starts_with("REGISTRIES") && s?ends_with("PREFIX")) as setting]
 
         [#local registryName = getOccurrenceSettingValue(occurrence, setting)?remove_ending('/')]
-        [#local registries += 
+        [#local registries +=
           {
             setting : {
               "Id": formatResourceId(AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, registryName),
@@ -112,11 +112,11 @@
   [#else]
     [#local container = core.SubComponent.Id]
   [/#if]
-  
+
   [#local containerName = formatAzureResourceName(container, AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, blobName)]
   [#local containerId = formatResourceId(AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, core.Id)]
 
-  [#local storageEndpoints = 
+  [#local storageEndpoints =
     getExistingReference(
       formatId(
         storageAccountId
@@ -163,7 +163,7 @@
 [#macro azure_baselinekey_arm_state occurrence parent={}]
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
-  
+
   [#local resources = {}]
 
   [#switch solution.Engine]

--- a/azure/components/s3/state.ftl
+++ b/azure/components/s3/state.ftl
@@ -17,15 +17,14 @@
         [/#if]
     [/#list]
 
-    [#local accountName = formatName(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, core.ShortName)]
     [#local blobName = "default"]
     [#local container = formatName(AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, core.ShortName)]
-    [#local accountName = formatAzureResourceName(accountName, AZURE_STORAGEACCOUNT_RESOURCE_TYPE)]
+    [#local accountName = formatAzureResourceName(core.ShortName, AZURE_STORAGEACCOUNT_RESOURCE_TYPE)]
     [#local blobName = formatAzureResourceName(blobName, AZURE_BLOBSERVICE_RESOURCE_TYPE, accountName)]
     [#local containerName = formatAzureResourceName(container, AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, blobName)]
     [#local secretName = formatSecretName(core.ShortName, "ConnectionKey")]
 
-    [#local storageEndpoints = 
+    [#local storageEndpoints =
         getExistingReference(
             formatId(
                 storageAccountId

--- a/azure/services/microsoft.storage/resource.ftl
+++ b/azure/services/microsoft.storage/resource.ftl
@@ -7,7 +7,7 @@
         {
             "apiVersion" : "2019-04-01",
             "type" : "Microsoft.Storage/storageAccounts",
-            "conditions" : [ "alphanumeric_only", "name_to_lower", "globally_unique", "max_length" ],
+            "conditions" : [ "name_to_lower", "globally_unique", "alphanumeric_only", "max_length" ],
             "max_name_length" : 24,
             "outputMappings" : {
                 REFERENCE_ATTRIBUTE_TYPE : {
@@ -323,7 +323,7 @@
 
 [#function formatAzureStorageListKeys storageId key=0]
     [#local apiVersion = getAzureResourceProfile(AZURE_STORAGEACCOUNT_RESOURCE_TYPE).apiVersion]
-    
+
     [#if storageId?starts_with("[")]
         [#-- child function, don't quote + remove boilerplate --]
         [#local storageId =
@@ -337,7 +337,7 @@
                 ?ensure_starts_with("'")
                 ?ensure_ends_with("'")]
     [/#if]
-    
+
     [#return
         "[listKeys(" + storageId + ", '" + apiVersion + "').keys[" + key + "].value]"
     ]


### PR DESCRIPTION
## Description
- Swap the ordering of the naming for storage accounts to make sure that only alphanumeric characters are used. 
- Update the naming of storage accounts so that we get the most out of the limited characters that we have available 

## Motivation and Context
Fix an issue with storage account deployments and to make it easier to determine the storage account you need

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [X] This will rename/replace the storage accounts which may impact active deployments

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
