### PR TITLE
feat(resources): incorporate scope into azureResourceProfiles

### DIFF
--- a/azure/services/resource.ftl
+++ b/azure/services/resource.ftl
@@ -40,6 +40,13 @@
                 "Names" : "global",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : false
+            },
+            {
+                "Names" : "scope",
+                "Description" : "The default deployment scope for a given resource type. Defaults to the parent template.",
+                "Type" : STRING_TYPE,
+                "Values" : [ "resourceGroup", "template", "pseudo" ],
+                "Default" : "template"
             }
         ]
     }
@@ -474,3 +481,4 @@ its own function to return the first split of the last segment --]
 [#function getAzureManagedIdentity linkTarget]
     [#return (linkTarget.Role)?has_content?then({ "type" : "SystemAssigned" },{})]
 [/#function]
+

--- a/azure/services/resource.ftl
+++ b/azure/services/resource.ftl
@@ -45,7 +45,7 @@
                 "Names" : "scope",
                 "Description" : "The default deployment scope for a given resource type. Defaults to the parent template.",
                 "Type" : STRING_TYPE,
-                "Values" : [ "resourceGroup", "template", "pseudo" ],
+                "Values" : [ "subscription", "resourceGroup", "template", "pseudo" ],
                 "Default" : "template"
             }
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a `scope` attribute to azureResourceProfiles, to define the default deployment scope for a given resource. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Contributes to #196 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Adds the capability but as yet unused anywhere.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
