### PR TITLE
refactor: setup macro support for entrances

### DIFF
--- a/azure/components/adaptor/setup.ftl
+++ b/azure/components/adaptor/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro azure_adaptor_arm_generationcontract_application occurrence]
+[#macro azure_adaptor_arm_deployment_generationcontract occurrence]
     [@addDefaultGenerationContract subsets=["prologue", "config", "epilogue"] /]
 [/#macro]
 
-[#macro azure_adaptor_arm_setup_application occurrence]
+[#macro azure_adaptor_arm_deployment occurrence]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/azure/components/apigateway/setup.ftl
+++ b/azure/components/apigateway/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_apigateway_arm_generationcontract_application occurrence]
+[#macro azure_apigateway_arm_deployment_generationcontract_application occurrence]
     [@addDefaultGenerationContract subsets=["pregeneration", "parameters", "template"] /]
 [/#macro]
 
-[#macro azure_apigateway_arm_setup_application occurrence]
+[#macro azure_apigateway_arm_deployment_application occurrence]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core          = occurrence.Core]

--- a/azure/components/baseline/setup.ftl
+++ b/azure/components/baseline/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro azure_baseline_arm_generationcontract_segment occurrence]
+[#macro azure_baseline_arm_deployment_generationcontract occurrence]
   [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue"] /]
 [/#macro]
 
-[#macro azure_baseline_arm_setup_segment occurrence]
+[#macro azure_baseline_arm_deployment occurrence]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/azure/components/bastion/setup.ftl
+++ b/azure/components/bastion/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro azure_bastion_arm_generationcontract_segment occurrence]
+[#macro azure_bastion_arm_deployment_generationcontract occurrence]
   [@addDefaultGenerationContract subsets=[ "template", "parameters"] /]
 [/#macro]
 
-[#macro azure_bastion_arm_setup_segment occurrence]
+[#macro azure_bastion_arm_deployment occurrence]
 
   [@debug message="Entering Bastion Setup" context=occurrence enabled=false /]
   [#local core = occurrence.Core]
@@ -26,7 +26,7 @@
   [#local networkVnetResource = networkResources["vnet"]]
   [#local subnetResource = getSubnet(core.Tier, networkResources)]
   [#local subnetName = formatAzureResourceName(
-    subnetResource.Name, 
+    subnetResource.Name,
     getResourceType(subnetResource.Id),
     networkVnetResource.Name
   )]
@@ -169,7 +169,7 @@
 
     [#-- TODO: rossmurr4y
     Add autoscaling configuration for the VMSS.
-    
+
     [#local autoScaleTargetId = autoScalePolicy.Reference]
 
     [#local autoScaleRule = getAutoScaleRule()]

--- a/azure/components/cdn/setup.ftl
+++ b/azure/components/cdn/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_cdn_arm_generationcontract_solution occurrence]
+[#macro azure_cdn_arm_deployment_generationcontract occurrence]
     [@addDefaultGenerationContract subsets=["template", "epilogue"] /]
 [/#macro]
 
-[#macro azure_cdn_arm_setup_solution occurrence]
+[#macro azure_cdn_arm_deployment occurrence]
 
     [@debug message="Entering CDN Component Setup" context=occurrence enabled=false /]
 
@@ -103,7 +103,7 @@
                 ]]
 
                 [#-- Create backend pools--]
-                [#local spaBackendPoolAddress = 
+                [#local spaBackendPoolAddress =
                     webEndpoint?remove_beginning("https://")?remove_ending("/")]
 
                 [#local spaBackendPool = [

--- a/azure/components/computecluster/setup.ftl
+++ b/azure/components/computecluster/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_computecluster_arm_generationcontract_application occurrence ]
+[#macro azure_computecluster_arm_deployment_generationcontract occurrence ]
     [@addDefaultGenerationContract subsets=[ "parameters", "template"] /]
 [/#macro]
 
-[#macro azure_computecluster_arm_setup_application occurrence]
+[#macro azure_computecluster_arm_deployment_application occurrence]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core          = occurrence.Core]
@@ -38,7 +38,7 @@
     [#local keyvaultId        = keyAttributes["KEYVAULT_ID"]]
 
     [#-- Default Storage Config --]
-    [#local stageStorage = 
+    [#local stageStorage =
         {
             "Account" : {
                 "Id" : storageAccountId,
@@ -111,7 +111,7 @@
                 [#break]
 
             [#case S3_COMPONENT_TYPE]
-                [#local stageStorage = 
+                [#local stageStorage =
                     {
                         "Account" : {
                             "Id" : linkTargetAttributes["ACCOUNT_ID"],
@@ -141,8 +141,8 @@
                             ?keys
                             ?filter(s -> s?starts_with("ENV_"))
                             ?filter(s -> !s?ends_with("SECRET")) as setting]
-                            
-                            [#local dbDetails += 
+
+                            [#local dbDetails +=
                                 { setting?remove_beginning("ENV_") : linkTargetConfiguration.Settings.Product[setting].Value }]
                         [/#list]
 
@@ -153,14 +153,14 @@
 
                         [#if linkTargetConfiguration.Solution["azure:Secrets"]??]
                             [#list linkTargetConfiguration.Solution["azure:Secrets"]?values as secret]
-                                [#local dbSecrets += 
+                                [#local dbSecrets +=
                                     [{ secret.Setting : secret.Name }]]
                             [/#list]
                         [/#if]
 
                         [#-- ENV Attributes --]
-                        [#local dbDetails += 
-                            { 
+                        [#local dbDetails +=
+                            {
                                 "DB_NAME" : linkTargetAttributes["DB_NAME"],
                                 "DB_USERNAME" : linkTargetAttributes["USERNAME"],
                                 "DB_HOST" : linkTargetAttributes["FQDN"]
@@ -168,7 +168,7 @@
 
                         [#break]
                 [/#switch]
-                    
+
                 [#list dbSecrets as dbSecret]
                     [#list dbSecret?values as secretName]
                         [@createKeyVaultParameterLookup
@@ -240,7 +240,7 @@
     [#-- Network Security Group Rules --]
     [#local priority = 200]
     [#list nsgRules?values as rule]
-        
+
         [#local destination = getReference(
             publicIp.Id,
             publicIp.Name,
@@ -279,12 +279,12 @@
         )]
 
     [#local nicIpConfigName = nic.Name + "ipConfig"]
-    [#local nicIpConfig = 
+    [#local nicIpConfig =
         getIPConfiguration(
             nicIpConfigName,
             getExistingReference(subnet.Id),
-            true, 
-            publicIp.Reference, 
+            true,
+            publicIp.Reference,
             "", "", [], "", "", "", "Dynamic", "IPv4", [],
             appGatewayBackendAddressPoolIds,
             lbBackendAddressPoolIds,
@@ -301,7 +301,7 @@
     /]
 
     [#local storageAccountType = [vmStorage.Tier, vmStorage.Replication]?join('_')]
-    
+
     [#local vmProfile =
         getVirtualMachineProfile(
             storageAccountType,
@@ -321,7 +321,7 @@
                                 "ipConfigurations",
                                 nicIpConfigName
                             )
-                        ) + 
+                        ) +
                         getIPConfiguration(nicIpConfigName, subnet.Reference)
 
                     ]
@@ -364,7 +364,7 @@
     [@armParameter name="container" default=stageStorage.Container /]
     [@armParameter name="blob" default=stageStorage.BlobPath /]
     [@armParameter name="file" default=stageStorage.BlobName /]
-    [@armParameter 
+    [@armParameter
         name="storage"
         default=
             formatAzureStorageAccountConnectionStringReference(
@@ -407,7 +407,7 @@
 
     [/#if]
     [#local indices = indices?sort]
-    
+
     [#local extensionScriptConfig = {}]
     [#list indices as index]
 
@@ -426,7 +426,7 @@
             [/#list]
         [/#if]
 
-        [#local extensionScriptConfig = 
+        [#local extensionScriptConfig =
             mergeObjects(extensionScriptConfig, extConfig)]
 
     [/#list]

--- a/azure/components/containerhost/setup.ftl
+++ b/azure/components/containerhost/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_containerhost_arm_generationcontract_solution occurrence]
+[#macro azure_containerhost_arm_deployment_generationcontract occurrence]
     [@addDefaultGenerationContract subsets=["template"] /]
 [/#macro]
 
-[#macro azure_containerhost_arm_setup_solution occurrence]
+[#macro azure_containerhost_arm_deployment occurrence]
 
     [@debug message="Entering Function ARM Setup" context=occurrence enabled=false /]
 

--- a/azure/components/db/setup.ftl
+++ b/azure/components/db/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_db_arm_generationcontract_solution occurrence]
+[#macro azure_db_arm_deployment_generationcontract occurrence]
     [@addDefaultGenerationContract subsets=["prologue", "parameters", "template"] /]
 [/#macro]
 
-[#macro azure_db_arm_setup_solution occurrence]
+[#macro azure_db_arm_deployment occurrence]
 
     [@debug message="Entering" context=occurrence enabled=false /]
 
@@ -12,10 +12,10 @@
     [#local solution   = occurrence.Configuration.Solution]
     [#local resources  = occurrence.State.Resources]
     [#local attributes = occurrence.State.Attributes]
-   
+
     [#local engine = solution.Engine]
     [#local engineVersion = solution.EngineMinorVersion?has_content?then(
-    solution.EngineVersion + solution.EngineMinorVersion, 
+    solution.EngineVersion + solution.EngineMinorVersion,
     solution.EngineVersion)]
 
     [#-- Resources --]
@@ -92,7 +92,7 @@
     [#-- Resource Creation --]
     [#if !hibernate]
         [#switch engine]
-            
+
             [#case "postgres"]
 
                 [@createPostgresServer
@@ -131,7 +131,7 @@
                     ] + configReferences
                 /]
 
-                [#-- TODO(rossmurr4y): 
+                [#-- TODO(rossmurr4y):
                     refactor `ignoreMissingEndpoint` alongside Service Endpoints.
                 --]
                 [@createPostgresServerVNetRule
@@ -147,5 +147,5 @@
                 [#break]
 
         [/#switch]
-    [/#if]  
+    [/#if]
 [/#macro]

--- a/azure/components/gateway/setup.ftl
+++ b/azure/components/gateway/setup.ftl
@@ -6,11 +6,11 @@
   privateEndpoint resources. Leaving large portions of the macro
   intact so as to outline the future structure.
 --]
-[#macro azure_gateway_arm_generationcontract_segment occurrence]
+[#macro azure_gateway_arm_deployment_generationcontract occurrence]
   [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro azure_gateway_arm_setup_segment occurrence]
+[#macro azure_gateway_arm_deployment occurrence]
 
   [#local gwCore = occurrence.Core]
   [#local gwSolution = occurrence.Configuration.Solution]

--- a/azure/components/lambda/setup.ftl
+++ b/azure/components/lambda/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_lambda_arm_generationcontract_application occurrence]
+[#macro azure_lambda_arm_deployment_generationcontract occurrence]
     [@addDefaultGenerationContract subsets=["template", "parameters", "epilogue"] /]
 [/#macro]
 
-[#macro azure_lambda_arm_setup_application occurrence]
+[#macro azure_lambda_arm_deployment occurrence]
 
     [@debug message="Entering Function ARM Setup" context=occurrence enabled=false /]
 
@@ -63,7 +63,7 @@
 
             [#-- Establish Parameter Lookup for any Secrets in final env --]
             [#local secrets = getSettingSecrets(_context.DefaultEnvironment, "")]
-            
+
             [#list secrets as secret]
                 [#list secret?values as secretName]
                     [@createKeyVaultParameterLookup

--- a/azure/components/lb/setup.ftl
+++ b/azure/components/lb/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_lb_arm_generationcontract_solution occurrence]
+[#macro azure_lb_arm_deployment_generationcontract occurrence]
     [@addDefaultGenerationContract subsets=["template"] /]
 [/#macro]
 
-[#macro azure_lb_arm_setup_solution occurrence]
+[#macro azure_lb_arm_deployment occurrence]
     [@debug message="Entering LB Setup" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
@@ -22,7 +22,7 @@
         [#return]
     [/#if]
     [#local networkResources = networkLinkTarget.State.Resources]
-    
+
     [#-- LB Resources --]
     [#local lb = resources["lb"]]
     [#local publicIP = resources["publicIP"]]
@@ -33,7 +33,7 @@
     [#-- Instantiate LB Configs --]
     [#switch engine]
         [#case "application"]
-            [#local gatewayIPConfigExists = false]     
+            [#local gatewayIPConfigExists = false]
             [#local listenerPortsSeen = []]
             [#local frontendIPAddress = {}]
             [#local portProtocols = []]
@@ -156,7 +156,7 @@
                                     publicIP.Reference
                                 )
                             ]]
-                            [#local frontendIPAddress += { 
+                            [#local frontendIPAddress += {
                                 "Configuration" : frontendIPConfiguration.SubReference,
                                 "Assigned" : true
                             }]
@@ -287,7 +287,7 @@
                     [/#list]
 
                     [#if ! redirectTargetListener?has_content]
-                        [@fatal 
+                        [@fatal
                             message="Target Listener for Redirect does not exist."
                             context=
                                 {
@@ -354,7 +354,7 @@
             /]
 
             [#if sslCertificate?has_content]
-                [#local identityObj = 
+                [#local identityObj =
                     {
                         "type" : "UserAssigned",
                         "userAssignedIdentities" : {

--- a/azure/components/network/setup.ftl
+++ b/azure/components/network/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro azure_network_arm_generationcontract_segment occurrence]
+[#macro azure_network_arm_deployment_generationcontract occurrence]
   [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro azure_network_arm_setup_segment occurrence]
+[#macro azure_network_arm_deployment occurrence]
   [@debug message="Entering" context=occurrence enabled=false /]
 
   [#local core = occurrence.Core]

--- a/azure/components/s3/setup.ftl
+++ b/azure/components/s3/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro azure_s3_arm_generationcontract_solution occurrence]
+[#macro azure_s3_arm_deployment_generationcontract occurrence]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro azure_s3_arm_setup_solution occurrence]
+[#macro azure_s3_arm_deployment occurrence]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/azure/components/spa/setup.ftl
+++ b/azure/components/spa/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_spa_arm_generationcontract_application occurrence]
+[#macro azure_spa_arm_deployment_generationcontract occurrence]
   [@addDefaultGenerationContract subsets=["prologue", "config", "epilogue"] /]
 [/#macro]
 
-[#macro azure_spa_arm_setup_application occurrence]
+[#macro azure_spa_arm_deployment occurrence]
 
   [@debug message="Entering SPA Setup" context=occurrence enabled=false /]
 

--- a/azure/components/sqs/setup.ftl
+++ b/azure/components/sqs/setup.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro azure_sqs_arm_generationcontract_solution occurrence]
+[#macro azure_sqs_arm_deployment_generationcontract occurrence]
     [#-- Queue creation is not yet available within ARM                --]
     [#-- No template is therefore required - all work done through CLI --]
     [#-- TODO(rossmurr4y): Keep an eye on ARM support:                 --]
@@ -8,7 +8,7 @@
     [@addDefaultGenerationContract subsets=["prologue"] /]
 [/#macro]
 
-[#macro azure_sqs_arm_setup_solution occurrence]
+[#macro azure_sqs_arm_deployment occurrence]
 
     [@debug message="Entering SQS Setup" context=occurrence enabled=false /]
 

--- a/azure/components/userpool/setup.ftl
+++ b/azure/components/userpool/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro azure_userpool_arm_generationcontract_solution occurrence]
+[#macro azure_userpool_arm_deployment_generationcontract occurrence]
     [@addDefaultGenerationContract subsets=["prologue"] /]
 [/#macro]
 
-[#macro azure_userpool_arm_setup_solution occurrence]
+[#macro azure_userpool_arm_deployment occurrence]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
@@ -38,7 +38,7 @@
 
         [#-- Resource SubComponent Processing --]
         [#if subCore.Type == USERPOOL_RESOURCE_COMPONENT_TYPE]
-            
+
             [#local subLinkTarget = getLinkTarget(subOccurrence, subSolution.Server.Link, false)]
 
             [#if !subLinkTarget?has_content]
@@ -90,7 +90,7 @@
                         [#if linkTargetAttributes["AUTH_SIGNOUT_URL"]?has_content]
                             [#local logoutUrls += [linkTargetAttributes["AUTH_SIGNOUT_URL"]]]
                         [/#if]
-                        
+
                         [#break]
 
                     [#case USERPOOL_AUTHPROVIDER_COMPONENT_TYPE]
@@ -116,14 +116,14 @@
                     attributeIfTrue("oauth2-allow-implicit-flow", flows?seq_contains("implicit"), true) +
                     attributeIfTrue("available-to-other-tenants", otherTenants, otherTenants)
                 ]
-                
+
             [/#if]
 
         [/#if]
 
     [/#list]
 
-    [#local creationcliArgs += {} + 
+    [#local creationcliArgs += {} +
         attributeIfContent("reply-urls", replyUrls?join(' '))]
 
     [#local updatesCliArgs += {} +
@@ -176,7 +176,7 @@
                 ]
             ) +
             [
-                "   create|update)",   
+                "   create|update)",
                 "       az ad app create " + args?join(" ") + " > $tmp/registration.json",
                 "       objectId=$(runJQ -r '.objectId' < $tmp/registration.json)",
                 "       clientId=$(runJQ -r '.appId' < $tmp/registration.json)"

--- a/azure/deploymentframeworks/arm/output.ftl
+++ b/azure/deploymentframeworks/arm/output.ftl
@@ -37,7 +37,7 @@
     }]
 [/#function]
 
-[#function getArmOutput name type value condition=""]  
+[#function getArmOutput name type value condition=""]
     [#return {
         name : {
             "type" : type,
@@ -215,7 +215,7 @@
     [#local minSegmentLength = 8]
     [#local validScope = true]
     [#if segments?size < minSegmentLength]
-        [@fatal 
+        [@fatal
             message="Resource Path is too short to determine scope."
             context={ "Path" : id }
         /]
@@ -253,7 +253,7 @@
     [/#if]
 
     [#if validScope]
-        [#return 
+        [#return
             {
                 "Resource" : {
                     "Name" : segments?sequence[resourceIndex + 1],
@@ -288,7 +288,7 @@
     [#if isPartOfCurrentDeploymentUnit(id)]
         [#local relativeScope = {}]
     [#else]
-        [#local resourceId = getExistingReference(id)]    
+        [#local resourceId = getExistingReference(id)]
         [#if resourceId?has_content]
             [#local targetScope = getResourceScopeFromResourcePath(resourceId)]
             [#local relativeScope = {} +
@@ -354,7 +354,7 @@
     resourceGroupId=""
     subscriptionId=""
     parentId=""]
-    
+
     [#if parentId?has_content]
         [#local resourceScope = getResourceRelativeScope(parentId)]
         [#local resourceGroupId = resourceScope.ResourceGroup!""]
@@ -452,7 +452,12 @@
     [#if include?has_content]
         [#include include?ensure_starts_with("/")]
     [#else]
-        [@processComponents level /]
+        [@processModelFlow
+            level=level
+            framework=AZURE_RESOURCE_MANAGER_DEPLOYMENT_FRAMEWORK
+            model=commandLineOptions.Deployment.Framework.Model
+            flow=commandLineOptions.Deployment.Framework.Flow
+        /]
     [/#if]
 
     [#if getOutputContent("resources")?has_content || logMessages?has_content]

--- a/azure/deploymentframeworks/arm/output.ftl
+++ b/azure/deploymentframeworks/arm/output.ftl
@@ -452,11 +452,10 @@
     [#if include?has_content]
         [#include include?ensure_starts_with("/")]
     [#else]
-        [@processModelFlow
+        [@processFlows
             level=level
             framework=AZURE_RESOURCE_MANAGER_DEPLOYMENT_FRAMEWORK
-            model=commandLineOptions.Deployment.Framework.Model
-            flow=commandLineOptions.Deployment.Framework.Flow
+            flows=commandLineOptions.Flow.Names
         /]
     [/#if]
 


### PR DESCRIPTION
## Description

Aligns the Azure component setup macros with the new entrances lookup
structure as part of the components flow introduced in
https://github.com/hamlet-io/engine/pull/1407

BREAKING CHANGE: setup marco names do not support the current naming
format

## Motivation and Context
Allows for dynamically loaded outputs to use a standard flow process through hamlet

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [ ] engine - https://github.com/hamlet-io/engine/pull/1407
- [ ] executor-bash - https://github.com/hamlet-io/executor-bash/pull/105
- [ ] engine-plugin-aws - https://github.com/hamlet-io/engine-plugin-aws/pull/132
- [ ] engine-plugin-azure - https://github.com/hamlet-io/engine-plugin-azure/pull/204 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
