### PR TITLE
refactor: move secret attribute to shared

### DIFF
--- a/azure/services/microsoft.keyvault/id.ftl
+++ b/azure/services/microsoft.keyvault/id.ftl
@@ -13,4 +13,3 @@
 [#-- Attribute Type --]
 [#-- The "secret" attribute type is an identifier for a KeyVault Secret. --]
 [#-- This is necessary to distinguish them from encrypted passwords.     --]
-[#assign SECRET_ATTRIBUTE_TYPE = "secret"]

--- a/azure/services/microsoft.keyvault/id.ftl
+++ b/azure/services/microsoft.keyvault/id.ftl
@@ -8,8 +8,3 @@
 [#assign AZURE_CMK_RESOURCE_TYPE = "cmk"]
 
 [#assign LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE = "sshPrivKey"]
-
-
-[#-- Attribute Type --]
-[#-- The "secret" attribute type is an identifier for a KeyVault Secret. --]
-[#-- This is necessary to distinguish them from encrypted passwords.     --]


### PR DESCRIPTION
## Description
Remove the definition of the SECRET_ATTRIBUTE_TYPE from the azure provider as its now available in the SHARED_PROVIDER ( https://github.com/hamlet-io/engine/pull/1485 ) 

## Motivation and Context
Allows for anyone to have a secret

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
