### PR TITLE
feat: migrate from fragments to extensions

### DIFF
--- a/azure/components/adaptor/setup.ftl
+++ b/azure/components/adaptor/setup.ftl
@@ -27,15 +27,9 @@
 
     [#local asFiles = getAsFileSettings(occurrence.Configuration.Settings.Product)]
 
-    [#local fragment = getOccurrenceFragmentBase(occurrence)]
-
     [#local contextLinks = getLinkTargets(occurrence)]
-    [#assign _context =
+    [#local _context =
         {
-            "Id" : fragment,
-            "Name" : fragment,
-            "Instance" : core.Instance.Id,
-            "Version" : core.Version.Id,
             "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "ContextSettings" : {},
@@ -48,9 +42,8 @@
         }
     ]
 
-    [#-- Add in fragment specifics including override of defaults --]
-    [#local fragmentId = formatFragmentId(_context)]
-    [#include fragmentList?ensure_starts_with("/")]
+    [#-- Add in extension specifics including override of defaults --]
+    [#local _context = invokeExtensions( occurrence, _context )]
 
     [#local EnvironmentSettings =
         {

--- a/azure/components/apigateway/setup.ftl
+++ b/azure/components/apigateway/setup.ftl
@@ -46,9 +46,7 @@
     ]
 
     [#-- Add in extension specifics including override of defaults --]
-    [#if solution.Extensions?has_content ]
-        [#local _context = invokeExtensions( occurrence, _context )]
-    [/#if]
+    [#local _context = invokeExtensions( occurrence, _context )]
 
     [#local stageVariables += getFinalEnvironment(occurrence, _context).Environment ]
 

--- a/azure/components/apigateway/setup.ftl
+++ b/azure/components/apigateway/setup.ftl
@@ -24,7 +24,6 @@
 
     [#-- Determine the stage variables required --]
     [#local stageVariables = {} ]
-    [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#-- Baselink Links --]
     [#local baselineLinks = getBaselineLinks(occurrence, ["SSHKey", "OpsData"], false, false)]
@@ -32,12 +31,8 @@
     [#local keyvault = baselineAttributes["KEYVAULT_ID"]]
 
     [#local contextLinks = getLinkTargets(occurrence)]
-    [#assign _context =
+    [#local _context =
         {
-            "Id" : fragment,
-            "Name" : fragment,
-            "Instance" : core.Instance.Id,
-            "Version" : core.Version.Id,
             "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
@@ -50,10 +45,9 @@
         }
     ]
 
-    [#-- Add in fragment specifics including override of defaults --]
-    [#if solution.Fragment?has_content ]
-        [#local fragmentId = formatFragmentId(_context)]
-        [#include fragmentList?ensure_starts_with("/")]
+    [#-- Add in extension specifics including override of defaults --]
+    [#if solution.Extensions?has_content ]
+        [#local _context = invokeExtensions( occurrence, _context )]
     [/#if]
 
     [#local stageVariables += getFinalEnvironment(occurrence, _context).Environment ]

--- a/azure/components/cdn/setup.ftl
+++ b/azure/components/cdn/setup.ftl
@@ -26,7 +26,6 @@
     [#-- Baseline lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ], false, false)]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks, "", "", "", "container")]
-    [#local fragment = getOccurrenceFragmentBase(occurrence)]
 
     [#local routingRules = []]
     [#local backendPools = []]
@@ -119,7 +118,7 @@
                         ],
                         getSubResourceReference(
                             getChildReference(
-                                frontDoor.Name, 
+                                frontDoor.Name,
                                 [
                                     getResourceObject(
                                         frontDoorLBSettingsName,

--- a/azure/components/lambda/setup.ftl
+++ b/azure/components/lambda/setup.ftl
@@ -30,14 +30,9 @@
 
         [#local appSettings = []]
 
-        [#local fragment = getOccurrenceFragmentBase(subOccurrence)]
         [#local contextLinks = getLinkTargets(subOccurrence)]
-        [#assign _context =
+        [#local _context =
             {
-                "Id" : fragment,
-                "Name" : fragment,
-                "Instance" : subCore.Instance.Id,
-                "Version" : subCore.Version.Id,
                 "DefaultEnvironment" : defaultEnvironment(subOccurrence, contextLinks, baselineLinks),
                 "Environment" : {},
                 "ContextSettings" : {},
@@ -49,9 +44,9 @@
                 "DefaultBaselineVariables" : false
             }
         ]
-        [#if subSolution.Fragment?has_content ]
-            [#local fragmentId = formatFragmentId(_context)]
-            [#include fragmentList?ensure_starts_with("/")]
+        [#if subSolution.Extensions?has_content ]
+            [#-- Add in extension specifics including override of defaults --]
+            [#local _context = invokeExtensions( subOccurrence, _context )]
         [/#if]
 
         [#if deploymentSubsetRequired("parameters", true)]

--- a/azure/components/lambda/setup.ftl
+++ b/azure/components/lambda/setup.ftl
@@ -44,10 +44,9 @@
                 "DefaultBaselineVariables" : false
             }
         ]
-        [#if subSolution.Extensions?has_content ]
-            [#-- Add in extension specifics including override of defaults --]
-            [#local _context = invokeExtensions( subOccurrence, _context )]
-        [/#if]
+
+        [#-- Add in extension specifics including override of defaults --]
+        [#local _context = invokeExtensions( subOccurrence, _context )]
 
         [#if deploymentSubsetRequired("parameters", true)]
 

--- a/azure/components/spa/setup.ftl
+++ b/azure/components/spa/setup.ftl
@@ -16,7 +16,6 @@
 
   [#local forwardingPath = attributes["FORWARDING_PATH"]?remove_beginning("/")]
 
-  [#local fragment = getOccurrenceFragmentBase(occurrence)]
   [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData"], false, false)]
   [#local storageAccount = baselineLinks["OpsData"].State.Attributes["ACCOUNT_NAME"]]
   [#local baselineComponentIds = getBaselineComponentIds(baselineLinks, "", "", "", "container")]
@@ -27,12 +26,8 @@
   [#local distributions = []]
 
   [#-- SPA Context --]
-  [#assign _context =
+  [#local _context =
     {
-      "Id" : fragment,
-      "Name" : fragment,
-      "Instance" : core.Instance.Id,
-      "Version" : core.Version.Id,
       "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
       "Environment" : {},
       "Links" : contextLinks,
@@ -44,11 +39,10 @@
     }
   ]
 
-  [#-- Add in container specifics including override of defaults --]
-  [#local fragmentId = formatFragmentId(_context)]
-  [#include fragmentList?ensure_starts_with("/")]
+  [#-- Add in extension specifics including override of defaults --]
+  [#local _context = invokeExtensions( subOccurrence, _context )]
 
-  [#assign _context += getFinalEnvironment(occurrence, _context)]
+  [#local _context += getFinalEnvironment(occurrence, _context)]
 
   [#list _context.Links as id,linkTarget]
 

--- a/azuretest/modules/adaptor/module.ftl
+++ b/azuretest/modules/adaptor/module.ftl
@@ -25,7 +25,7 @@
                                 "Profiles" : {
                                     "Testing" : [ "Component" ]
                                 },
-                                "Fragment" : "MockFragment"
+                                "Extensions" : [ "MockFragment" ]
                             }
                         }
                     }

--- a/azuretest/modules/lambda/module.ftl
+++ b/azuretest/modules/lambda/module.ftl
@@ -30,7 +30,7 @@
                                     "api" : {
                                         "Handler" : "src/handler.api",
                                         "RunTime" : "nodejs",
-                                        "Fragment" : "_mockfrag",
+                                        "Extensions" : [ "_mockext" ],
                                         "Links" : {}
                                     }
                                 }


### PR DESCRIPTION
## Description
Azure provider implementation of https://github.com/hamlet-io/engine/pull/1494 

Migrates all components which support fragments over to extensions
processing. 

## Motivation and Context
This allows for extensions to be defined as part of plugins
and also allows for multiple extensions to be used on a component

## How Has This Been Tested?
tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires: https://github.com/hamlet-io/engine/pull/1494

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
