### PR TITLE
Bugfix - getReference and Pseudo Resource Profiles

### DIFF
--- a/azure/deploymentframeworks/arm/output.ftl
+++ b/azure/deploymentframeworks/arm/output.ftl
@@ -98,7 +98,7 @@
 
         [#-- Pseudo resources simply output their name so they can be verified as deployed --]
         [#case "pseudo"]
-            [#return getArmOutput(name, "string", "pseudo")]
+            [#return getArmOutput(name, "string", name)]
             [#break]
 
     [/#switch]
@@ -281,7 +281,7 @@
     [#--          The marker indicates the minimum scope to which a resource exists.                --]
     [#local resourceProfileScope = getAzureResourceProfile(getResourceType(id)).scope]
     [#local currentScope = {
-        "Subscription" : accountObject.AzureId,
+        "Subscription" : accountObject.AzureId!"",
         "ResourceGroup" : commandLineOptions.Deployment.ResourceGroup.Name
     }]
 

--- a/azure/services/resource.ftl
+++ b/azure/services/resource.ftl
@@ -159,6 +159,11 @@
         [#return ""]
     [/#if]
 
+    [#-- Check if its an undeployed pseudo stack --]
+    [#if (profile.type == "pseudo") && !(name?has_content)]
+        [#return getExistingReference(id, attributeType)]
+    [/#if]
+
     [#-- To access the properties of a resource in the same scope              --]
     [#-- it is necessary to wrap a "resourceId" function in a                  --]
     [#-- "reference" function.                                                 --]


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit updates getReference() with a check to see if its working
with a pseudo resource profile. If it is, it calls getExistingReference instead of incorrectly constructing an ARM `[referenceId()]` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The baseline component uses a pseudo resource profile to represent the "seed". If it hasn't been deployed yet (in the prologue) but the template pass runs, `getReference()` incorrectly formats an ARM function. This then becomes part of the name of the KeyVault, which then becomes a part of the name for a KeyVault Secret, and its all a huge (invalid) mess.

```bash
{"error":{"code":"InvalidTemplate","message":"Deployment template language expression evaluation failed: 'Unable to parse language expression 'resourceId('Microsoft.KeyVault/vaults', 'vault-[resourceId('pseudo', '')]')': expected token 'RightParenthesis' and actual 'Identifier'.'. Please see https://aka.ms/arm-template-expressions for usage details.","additionalInfo":[{"type":"TemplateViolation","info":{"lineNumber":0,"linePosition":0,"path":""}}]}}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and subsequent test deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
