### PR TITLE
Fix - Azure Provider Tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@ pipeline {
 
     stages {
 
-        /*
         stage('Run Azure Template Tests') {
             environment {
                 GENERATION_PLUGIN_DIRS = "${WORKSPACE}"
@@ -25,7 +24,6 @@ pipeline {
                 '''
             }
         }
-        */
 
         stage('Trigger Docker Build') {
             steps {

--- a/azure/components/baseline/state.ftl
+++ b/azure/components/baseline/state.ftl
@@ -5,10 +5,10 @@
   [#local solution = occurrence.Configuration.Solution]
 
   [#local segmentSeedId = formatSegmentSeedId() ]
-  [#if !(getReference(segmentSeedId)?has_content) ]
+  [#if !(getExistingReference(segmentSeedId)?has_content) ]
     [#local segmentSeedValue = (commandLineOptions.Run.Id + accountObject.Seed)[0..(solution.Seed.Length - 1)]]
   [#else]
-    [#local segmentSeedValue = getReference(segmentSeedId) ]
+    [#local segmentSeedValue = getExistingReference(segmentSeedId) ]
   [/#if]
 
   [#local storageAccountId = formatResourceId(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, core.Id)]

--- a/azure/components/spa/setup.ftl
+++ b/azure/components/spa/setup.ftl
@@ -40,7 +40,7 @@
   ]
 
   [#-- Add in extension specifics including override of defaults --]
-  [#local _context = invokeExtensions( subOccurrence, _context )]
+  [#local _context = invokeExtensions(occurrence, _context )]
 
   [#local _context += getFinalEnvironment(occurrence, _context)]
 

--- a/azure/deploymentframeworks/arm/output.ftl
+++ b/azure/deploymentframeworks/arm/output.ftl
@@ -299,8 +299,7 @@
                     {
                             "ResourceId" : id,
                             "CurrentScope" : currentScope,
-                            "TargetScope" : targetScope,
-                            "RelativeScope" : relativeScope
+                            "TargetScope" : targetScope
                         }
                 /]
             [/#if]

--- a/azure/deploymentframeworks/arm/output.ftl
+++ b/azure/deploymentframeworks/arm/output.ftl
@@ -288,7 +288,7 @@
     [#if isPartOfCurrentDeploymentUnit(id)]
         [#local relativeScope = {}]
     [#else]
-        [#local resourceId = getReference(id)]    
+        [#local resourceId = getExistingReference(id)]    
         [#if resourceId?has_content]
             [#local targetScope = getResourceScopeFromResourcePath(resourceId)]
 

--- a/azure/inputsources/mock/blueprint.ftl
+++ b/azure/inputsources/mock/blueprint.ftl
@@ -6,11 +6,11 @@
         blueprint=
         {
             "Account": {
-                "Region": "westus",
-                "ProviderId": "0123456789"
+                "Region": AZURE_REGION_MOCK_VALUE,
+                "ProviderId": AZURE_SUBSCRIPTION_MOCK_VALUE
             },
             "Product": {
-                "Region": "westus"
+                "Region": AZURE_REGION_MOCK_VALUE
             }
         }
     /]

--- a/azure/inputsources/mock/commandlineoption.ftl
+++ b/azure/inputsources/mock/commandlineoption.ftl
@@ -6,12 +6,12 @@
         option=
             {
                 "Regions" : {
-                    "Segment" : "westus",
-                    "Account" : "westus"
+                    "Segment" : AZURE_REGION_MOCK_VALUE,
+                    "Account" : AZURE_REGION_MOCK_VALUE
                 },
                 "Deployment" : {
                     "ResourceGroup" : {
-                        "Name" : "mockRG"
+                        "Name" : AZURE_RESOURCEGROUP_MOCK_VALUE
                     },
                     "Unit" : {
                         "Name" : getDeploymentUnit()

--- a/azure/inputsources/mock/stackoutput.ftl
+++ b/azure/inputsources/mock/stackoutput.ftl
@@ -2,50 +2,31 @@
 
 [#macro azure_input_mock_stackoutput id="" deploymentUnit="" level="" region="" account=""]
 
-  [#local mockSubscription = accountObject.ProviderId]
-  [#local mockResourceGroup = "mockRG"]
-  [#local mockProvider = "Microsoft.Mock"]
-  [#local mockRegion = "mockedRegion"]
-  [#local mockResourceType = "mockResourceType"]
-  [#local mockResourceName = "mockResourceName"]
-
   [#switch id?split("X")?last ]
     [#case NAME_ATTRIBUTE_TYPE]
-      [#local value = "mockResourceName"]
+      [#local value = AZURE_RESOURCE_NAME_MOCK_VALUE]
       [#break]
     [#case URL_ATTRIBUTE_TYPE ]
-      [#local value = "https://mock.local/" + id ]
+      [#local value = AZURE_RESOURCE_URL_MOCK_VALUE + id ]
       [#break]
     [#case IP_ADDRESS_ATTRIBUTE_TYPE ]
-      [#local value = "123.123.123.123" ]
+      [#local value = AZURE_RESOURCE_IP_ADDRESS_MOCK_VALUE ]
       [#break]
     [#case REGION_ATTRIBUTE_TYPE ]
-      [#local value = "westus" ]
+      [#local value = AZURE_REGION_MOCK_VALUE ]
       [#break]
     [#default]
       [#--The default value will be an azure resource Id --]
-      [#local value = formatPath(
-                        true, 
-                        [
-                          "subscriptions", 
-                          mockSubscription, 
-                          "resourceGroups", 
-                          mockResourceGroup, 
-                          "providers", 
-                          mockProvider, 
-                          mockResourceType, 
-                          mockResourceName
-                        ] 
-      )]
+      [#local value = AZURE_RESOURCE_ID_MOCK_VALUE]
       [#break]
     [/#switch]
 
     [@addStackOutputs 
       [
         {
-          "Subscription" : account,
-          "Region" : region,
-          "DeploymentUnit" : deploymentUnit,
+          "Subscription" : account!AZURE_SUBSCRIPTION_MOCK_VALUE,
+          "Region" : region!AZURE_REGION_MOCK_VALUE,
+          "DeploymentUnit" : deploymentUnit!getDeploymentUnit(),
           id : value
         }
       ]

--- a/azure/inputsources/mock/stackoutput.ftl
+++ b/azure/inputsources/mock/stackoutput.ftl
@@ -2,6 +2,13 @@
 
 [#macro azure_input_mock_stackoutput id="" deploymentUnit="" level="" region="" account=""]
 
+  [#local mockSubscription = accountObject.ProviderId]
+  [#local mockResourceGroup = "mockRG"]
+  [#local mockProvider = "Microsoft.Mock"]
+  [#local mockRegion = "mockedRegion"]
+  [#local mockResourceType = "mockResourceType"]
+  [#local mockResourceName = "mockResourceName"]
+
   [#switch id?split("X")?last ]
     [#case NAME_ATTRIBUTE_TYPE]
       [#local value = "mockResourceName"]
@@ -13,11 +20,24 @@
       [#local value = "123.123.123.123" ]
       [#break]
     [#case REGION_ATTRIBUTE_TYPE ]
-      [#local value = "apmock1" ]
+      [#local value = "westus" ]
       [#break]
     [#default]
       [#--The default value will be an azure resource Id --]
-      [#local value = "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"]
+      [#local value = formatPath(
+                        true, 
+                        [
+                          "subscriptions", 
+                          mockSubscription, 
+                          "resourceGroups", 
+                          mockResourceGroup, 
+                          "providers", 
+                          mockProvider, 
+                          mockResourceType, 
+                          mockResourceName
+                        ] 
+      )]
+      [#break]
     [/#switch]
 
     [@addStackOutputs 

--- a/azure/references/SkuProfile/reference.ftl
+++ b/azure/references/SkuProfile/reference.ftl
@@ -1,9 +1,13 @@
 [#ftl]
 
-[@addReferenceData type=SKU_PROFILE_REFERENCE_TYPE base=blueprintObject /]
-[#assign skuProfiles = getReferenceData(SKU_PROFILE_REFERENCE_TYPE)]
+[@addReferenceData
+    type=SKU_PROFILE_REFERENCE_TYPE
+    base=blueprintObject
+/]
 
-[#function getSkuProfile occurrence type extensions... ]	
+[#function getSkuProfile occurrence type extensions... ]
+    [#local skuProfiles = 
+        getReferenceData(SKU_PROFILE_REFERENCE_TYPE)]
     [#local tc = formatComponentShortName(	
                     occurrence.Core.Tier,	
                     occurrence.Core.Component,	

--- a/azure/references/VMImageProfile/reference.ftl
+++ b/azure/references/VMImageProfile/reference.ftl
@@ -1,13 +1,17 @@
 [#ftl]
 
-[@addReferenceData type=VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE base=blueprintObject /]
-[#assign vmImageProfiles = getReferenceData(VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE) ]
+[@addReferenceData 
+    type=VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE
+    base=blueprintObject 
+/]
 
 [#function getVMImageProfile occurrence type extensions... ]	
+    [#local vmImageProfiles = 
+        getReferenceData(VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE)]
     [#local tc = formatComponentShortName(	
                     occurrence.Core.Tier,	
                     occurrence.Core.Component,	
-                    extensions)]	
+                    extensions)]
     [#local defaultProfile = "default"]	
     [#if (vmImageProfiles[defaultProfile][tc])??]	
         [#return vmImageProfiles[defaultProfile][tc]]	

--- a/azuretest/modules/adaptor/module.ftl
+++ b/azuretest/modules/adaptor/module.ftl
@@ -16,7 +16,7 @@
                 "Scope" : "Products",
                 "Namespace" : "mockedup-integration-azure-adaptor-base",
                 "Settings" : {
-                    "COMMIT" : "123456789#MockCommit#",
+                    "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
                     "FORMATS" : ["lambda"]
                 }
             }

--- a/azuretest/modules/apigateway/module.ftl
+++ b/azuretest/modules/apigateway/module.ftl
@@ -16,7 +16,7 @@
                 "Scope" : "Products",
                 "Namespace" : "mockedup-integration-application-az-apigateway-base",
                 "Settings" : {
-                    "COMMIT" : "123456789#MockCommit#",
+                    "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
                     "FORMATS" : ["openapi"]
                 }
             },
@@ -74,7 +74,7 @@
                             "Match" : {
                                 "APIMID" : {
                                     "Path" : "outputs.serviceXmockedupXintegrationXapiXapigateway.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/baseline/module.ftl
+++ b/azuretest/modules/baseline/module.ftl
@@ -38,7 +38,7 @@
                             "Match" : {
                                 "BaselineStorageID" : {
                                     "Path" : "outputs.storageXmgmtXbaseline.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/bastion/module.ftl
+++ b/azuretest/modules/bastion/module.ftl
@@ -16,7 +16,7 @@
             "Tiers" : {
                 "mgmt" : {
                     "Components" : {
-                        "ssh" : {
+                        "bastion" : {
                             "bastion" : {
                                 "Instances" : {
                                     "default" : {

--- a/azuretest/modules/bastion/module.ftl
+++ b/azuretest/modules/bastion/module.ftl
@@ -40,8 +40,8 @@
                         "JSON" : {
                             "Match" : {
                                 "ScaleSetID" : {
-                                    "Path" : "outputs.vmssXmanagementXsshXbastion.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Path" : "outputs.vmssXmanagementXbastionXbastion.value",
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/cdn/module.ftl
+++ b/azuretest/modules/cdn/module.ftl
@@ -46,7 +46,7 @@
                             "Match" : {
                                 "FrontDoorID" : {
                                     "Path" : "outputs.frontdoorXwebXcdn.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/computecluster/module.ftl
+++ b/azuretest/modules/computecluster/module.ftl
@@ -16,7 +16,7 @@
                 "Scope" : "Products",
                 "Namespace" : "mockedup-integration-application-az-computecluster-base",
                 "Settings" : {
-                    "COMMIT" : "123456789#MockCommit#"
+                    "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE
                 }
             },
             {
@@ -102,7 +102,7 @@
                             "Match" : {
                                 "ScaleSetID" : {
                                     "Path" : "outputs.vmssXsettingsXappXcomputecluster.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/lambda/module.ftl
+++ b/azuretest/modules/lambda/module.ftl
@@ -17,7 +17,7 @@
                 "Scope" : "Products",
                 "Namespace" : "mockedup-integration-application-az-lambda-base",
                 "Settings" : {
-                    "COMMIT" : "123456789#MockCommit#",
+                    "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
                     "FORMATS" : ["lambda"]
                 }
             }
@@ -57,7 +57,7 @@
                             "Match" : {
                                 "AppServicePlanID" : {
                                     "Path" : "outputs.sitesXappXlambdaXapi.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/lb/module.ftl
+++ b/azuretest/modules/lb/module.ftl
@@ -44,7 +44,7 @@
                             "Match" : {
                                 "AppGatewayID" : {
                                     "Path" : "outputs.appGatewayXmockedupXintegrationXelbXlb.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/network/module.ftl
+++ b/azuretest/modules/network/module.ftl
@@ -82,7 +82,7 @@
                             "Match" : {
                                 "VNetID" : {
                                     "Path" : "outputs.vnetXmgmtXvnet.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/s3/module.ftl
+++ b/azuretest/modules/s3/module.ftl
@@ -46,7 +46,7 @@
                             "Match" : {
                                 "StorageID" : {
                                     "Path" : "outputs.storageXappXstage.value",
-                                    "Value" : "/subscriptions/12345678-abcd-efgh-ijkl-123456789012/resourceGroups/mockRG/providers/Microsoft.Mock/mockR/mock-resource-name"
+                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
                                 }
                             }
                         }

--- a/azuretest/modules/spa/module.ftl
+++ b/azuretest/modules/spa/module.ftl
@@ -16,7 +16,7 @@
                 "Scope" : "Products",
                 "Namespace" : "mockedup-integration-application-az-spa-base",
                 "Settings" : {
-                    "COMMIT" : "123456789#MockCommit#",
+                    "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
                     "FORMATS" : ["spa"]
                 }
             }

--- a/azuretest/provider.ftl
+++ b/azuretest/provider.ftl
@@ -12,4 +12,29 @@
     Make sure to add the data appropriately
 
 --]
-[#assign AZURETEST_PROVIDER = "azuretest"]
+[#assign AZURETEST_PROVIDER = "azuretest" ]
+
+[#-- Globals to ensure consistency across testing provider --]
+[#assign AZURE_REGION_MOCK_VALUE = "westus" ]
+[#assign AZURE_SUBSCRIPTION_MOCK_VALUE = "0123456789" ]
+[#assign AZURE_RESOURCEGROUP_MOCK_VALUE = "mockRG" ]
+[#assign AZURE_SERVICE_NAME_MOCK_VALUE = "Microsoft.Mock" ]
+[#assign AZURE_RESOURCE_TYPE_MOCK_VALUE = "mockResourceType" ]
+[#assign AZURE_RESOURCE_NAME_MOCK_VALUE = "mockName" ]
+[#assign AZURE_RESOURCE_ID_MOCK_VALUE = 
+    formatPath(
+        true, 
+        [
+            "subscriptions", 
+            AZURE_SUBSCRIPTION_MOCK_VALUE, 
+            "resourceGroups", 
+            AZURE_RESOURCEGROUP_MOCK_VALUE, 
+            "providers", 
+            AZURE_SERVICE_NAME_MOCK_VALUE, 
+            AZURE_RESOURCE_TYPE_MOCK_VALUE, 
+            AZURE_RESOURCE_NAME_MOCK_VALUE
+        ] 
+    )]
+[#assign AZURE_RESOURCE_URL_MOCK_VALUE = "https://mock.local/" ]
+[#assign AZURE_RESOURCE_IP_ADDRESS_MOCK_VALUE = "123.123.123.123" ]
+[#assign AZURE_BUILD_COMMIT_MOCK_VALUE = "123456789#MockCommit#" ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* corrects the way the segmentSeed is sought/resolved in c403198 and simmillarly for outputs in 609ac54
* corrects relative scope issues when mocking in f0b95dd (Closes #216)
* corrects an early loading of provider-specific referenceData in 3c3db03 + e6ea316
* fixes a call to invokeExtension() in the `spa` component that passes an invalid variable in 782ebd1
* standardises mock values in the testing provider to keep values aligned in 164d969
* Re-enables CI testing
* Corrects A number of minor fixes that the testing picked up

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses and Closes #216 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests now pass locally with:
```bash
./test/run_azure_template_tests.sh
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] None of the above.
