### PR TITLE
feat: input seeders

### DIFF
--- a/azure/inputseeders/azure/id.ftl
+++ b/azure/inputseeders/azure/id.ftl
@@ -1,0 +1,139 @@
+[#ftl]
+
+[@addInputSeeder
+    id=AZURE_INPUT_SEEDER
+    description="Azure provider inputs"
+/]
+
+[@addSeederToInputStage
+    inputStage=MASTERDATA_SHARED_INPUT_STAGE
+    inputSeeder=AZURE_INPUT_SEEDER
+/]
+
+[@addSeederToInputStage
+    inputStage=MOCK_SHARED_INPUT_STAGE
+    inputSeeder=AZURE_INPUT_SEEDER
+/]
+
+[@addSeederToInputStage
+    inputSources=[MOCK_SHARED_INPUT_SOURCE]
+    inputStage=COMMANDLINEOPTIONS_SHARED_INPUT_STAGE
+    inputSeeder=AZURE_INPUT_SEEDER
+
+/]
+
+[#macro azure_input_loader path]
+    [#assign azure_cmdb_regions =
+        (
+            getPluginTree(
+                path,
+                {
+                    "AddStartingWildcard" : false,
+                    "AddEndingWildcard" : false,
+                    "MinDepth" : 1,
+                    "MaxDepth" : 1,
+                    "FilenameGlob" : "regions.json"
+                }
+            )[0].ContentsAsJSON
+        )!{}
+    ]
+    [#assign azure_cmdb_masterdata =
+        (
+            getPluginTree(
+                path,
+                {
+                    "AddStartingWildcard" : false,
+                    "AddEndingWildcard" : false,
+                    "MinDepth" : 1,
+                    "MaxDepth" : 1,
+                    "FilenameGlob" : "masterdata.json"
+                }
+            )[0].ContentsAsJSON
+        )!{}
+    ]
+[/#macro]
+
+[#function azure_input_masterdata_seeder filter state]
+
+    [#if getFilterAttribute(filter, "Provider")?seq_contains(AZURE_PROVIDER)]
+        [#local requiredRegions =
+            getArrayIntersection(
+                getFilterAttribute(filter, "Region")
+                azure_cmdb_regions?keys
+            )
+        ]
+        [#if requiredRegions?has_content]
+            [#local regions = getObjectAttributes(azure_cmdb_regions, requiredRegions) ]
+        [#else]
+            [#local regions = azure_cmdb_regions]
+        [/#if]
+        [#return
+            mergeObjects(
+                state,
+                {
+                    "Masterdata" :
+                        azure_cmdb_masterdata +
+                        {
+                            "Regions" : regions
+                        }
+                }
+            )
+        ]
+    [#else]
+        [#return state]
+    [/#if]
+
+[/#function]
+
+[#function azure_input_mock_seeder filter state]
+
+    [#if getFilterAttribute(filter, "Provider")?seq_contains(AZURE_PROVIDER)]
+        [#return
+            mergeObjects(
+                state,
+                {
+                    "Blueprint" :
+                    {
+                        "Account": {
+                            "Region": AZURE_REGION_MOCK_VALUE,
+                            "ProviderId": AZURE_SUBSCRIPTION_MOCK_VALUE
+                        },
+                        "Product": {
+                            "Region": AZURE_REGION_MOCK_VALUE
+                        }
+                    }
+                }
+            )
+        ]
+    [#else]
+        [#return state]
+    [/#if]
+
+[/#function]
+
+[#function azure_input_commandlineoption_mock_seeder filter state]
+
+    [#if getFilterAttribute(filter, "Provider")?seq_contains(AZURE_PROVIDER)]
+        [#return
+            mergeObjects(
+                state,
+                {
+                    "CommandLineOptions" : {
+                        "Regions" : {
+                            "Segment" : AZURE_REGION_MOCK_VALUE,
+                            "Account" : AZURE_REGION_MOCK_VALUE
+                        },
+                        "Deployment" : {
+                            "ResourceGroup" : {
+                                "Name" : AZURE_RESOURCEGROUP_MOCK_VALUE
+                            },
+                            "Unit" : {
+                                "Name" : getDeploymentUnit()
+                            }
+                        }
+                    }
+                }
+            )
+        ]
+    [/#if]
+[/#function]

--- a/azure/inputseeders/azure/id.ftl
+++ b/azure/inputseeders/azure/id.ftl
@@ -22,7 +22,7 @@
 
 /]
 
-[#macro azure_input_loader path]
+[#macro azure_inputloader path]
     [#assign azure_cmdb_regions =
         (
             getPluginTree(
@@ -53,7 +53,7 @@
     ]
 [/#macro]
 
-[#function azure_input_masterdata_seeder filter state]
+[#function azure_inputseeder_masterdata filter state]
 
     [#if getFilterAttribute(filter, "Provider")?seq_contains(AZURE_PROVIDER)]
         [#local requiredRegions =
@@ -85,7 +85,7 @@
 
 [/#function]
 
-[#function azure_input_mock_seeder filter state]
+[#function azure_inputseeder_mock filter state]
 
     [#if getFilterAttribute(filter, "Provider")?seq_contains(AZURE_PROVIDER)]
         [#return
@@ -111,7 +111,7 @@
 
 [/#function]
 
-[#function azure_input_commandlineoption_mock_seeder filter state]
+[#function azure_inputseeder_commandlineoption_mock filter state]
 
     [#if getFilterAttribute(filter, "Provider")?seq_contains(AZURE_PROVIDER)]
         [#return

--- a/azure/inputseeders/azure/masterdata.json
+++ b/azure/inputseeders/azure/masterdata.json
@@ -1,0 +1,653 @@
+{
+    "Tiers": {
+        "api": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Private"
+            }
+        },
+        "ana": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Private"
+            }
+        },
+        "app": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Private"
+            }
+        },
+        "db": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Private"
+            }
+        },
+        "dir": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Private"
+            }
+        },
+        "docs": {},
+        "elb": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Public"
+            }
+        },
+        "gbl": {
+            "Components": {}
+        },
+        "ilb": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Private"
+            }
+        },
+        "mgmt": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Public"
+            },
+            "Components": {
+                "baseline": {
+                    "DeploymentUnits": [
+                        "baseline"
+                    ],
+                    "baseline": {
+                        "DataBuckets": {
+                            "opsdata": {
+                                "Role": "operations",
+                                "Lifecycles": {
+                                    "awslogs": {
+                                        "Prefix": "AWSLogs",
+                                        "Expiration": "_operations",
+                                        "Offline": "_operations"
+                                    },
+                                    "cloudfront": {
+                                        "Prefix": "CLOUDFRONTLogs",
+                                        "Expiration": "_operations",
+                                        "Offline": "_operations"
+                                    },
+                                    "docker": {
+                                        "Prefix": "DOCKERLogs",
+                                        "Expiration": "_operations",
+                                        "Offline": "_operations"
+                                    }
+                                },
+                                "Links": {
+                                    "cf_key": {
+                                        "Tier": "mgmt",
+                                        "Component": "baseline",
+                                        "Instance": "",
+                                        "Version": "",
+                                        "Key": "oai"
+                                    }
+                                }
+                            },
+                            "appdata": {
+                                "Role": "appdata",
+                                "Lifecycles": {
+                                    "global": {
+                                        "Expiration": "_data",
+                                        "Offline": "_data"
+                                    }
+                                }
+                            },
+                            "web": {
+                                "Role": "staticWebsite"
+                            }
+                        },
+                        "Keys": {
+                            "ssh": {
+                                "Engine": "ssh",
+                                "IPAddressGroups": [
+                                    "_global"
+                                ]
+                            },
+                            "cmk": {
+                                "Engine": "cmk"
+                            },
+                            "oai": {
+                                "Engine": "oai"
+                            }
+                        }
+                    }
+                },
+                "ssh": {
+                    "DeploymentUnits": [
+                        "ssh"
+                    ],
+                    "MultiAZ": true,
+                    "bastion": {
+                        "AutoScaling": {
+                            "DetailedMetrics": false,
+                            "ActivityCooldown": 180,
+                            "MinUpdateInstances": 0,
+                            "AlwaysReplaceOnUpdate": false
+                        }
+                    }
+                },
+                "vpc": {
+                    "DeploymentUnits": [
+                        "vpc"
+                    ],
+                    "MultiAZ": true,
+                    "network": {
+                        "RouteTables": {
+                            "default": {}
+                        },
+                        "NetworkACLs": {
+                            "Public": {
+                                "Rules": {
+                                    "internetAccess": {
+                                        "Priority": 200,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_localnet"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_global"
+                                            ],
+                                            "Port": "any"
+                                        },
+                                        "ReturnTraffic": false
+                                    }
+                                }
+                            },
+                            "Private": {
+                                "Rules": {
+                                    "internetAccess": {
+                                        "Priority": 200,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_localnet"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_global"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "blockInbound": {
+                                        "Priority": 100,
+                                        "Action": "deny",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_global"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_localnet"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "Links": {
+                            "NetworkEndpoints": {
+                                "Tier": "mgmt",
+                                "Component": "vpcendpoint",
+                                "Version": "",
+                                "Instance": "",
+                                "Destination": "default"
+                            }
+                        }
+                    }
+                },
+                "vpcendpoint": {
+                    "DeploymentUnits": [
+                        "vpcendpoint"
+                    ],
+                    "gateway": {
+                        "Engine": "privateservice",
+                        "Destinations": {
+                            "default": {
+                                "NetworkEndpointGroups": [
+                                    "storage",
+                                    "logs"
+                                ],
+                                "Links": {
+                                    "Private": {
+                                        "Tier": "mgmt",
+                                        "Component": "vpc",
+                                        "Version": "",
+                                        "Instance": "",
+                                        "RouteTable": "default"
+                                    },
+                                    "Public": {
+                                        "Tier": "mgmt",
+                                        "Component": "vpc",
+                                        "Version": "",
+                                        "Instance": "",
+                                        "RouteTable": "default"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "msg": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Private"
+            }
+        },
+        "shared": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Public"
+            }
+        },
+        "web": {
+            "Network": {
+                "RouteTable": "default",
+                "NetworkACL": "Private"
+            }
+        }
+    },
+    "Ports": {
+        "gatewaymanager": {
+            "PortRange": {
+                "From": 65200,
+                "To": 65535
+            },
+            "IPProtocol": "all"
+        }
+    },
+    "Storage": {
+        "default": {
+            "storageAccount": {
+                "Tier": "Standard",
+                "Replication": "LRS",
+                "Type": "StorageV2",
+                "AccessTier": "Cool",
+                "HnsEnabled": false
+            },
+            "computecluster": {
+                "Tier": "Standard",
+                "Replication": "LRS"
+            },
+            "containerhost": {},
+            "containerservice": {},
+            "containertask": {}
+        },
+        "Blob": {
+            "storageAccount": {
+                "Tier": "Standard",
+                "Replication": "LRS",
+                "Type": "BlobStorage",
+                "AccessTier": "Cool",
+                "HnsEnabled": false
+            }
+        },
+        "File": {
+            "storageAccount": {
+                "Tier": "Standard",
+                "Replication": "LRS",
+                "Type": "FileStorage",
+                "HnsEnabled": false
+            }
+        },
+        "Block": {
+            "storageAccount": {
+                "Tier": "Standard",
+                "Replication": "LRS",
+                "Type": "BlockBlobStorage",
+                "HnsEnabled": false
+            }
+        }
+    },
+    "Processors": {
+        "default": {
+            "bastion": {
+                "Processor": "Standard_B1s"
+            },
+            "db": {
+                "Processor": "GP_Gen5_2"
+            },
+            "containerhost": {
+                "MaxCount": 2,
+                "MinCount": 1,
+                "DesiredCount": 1
+            },
+            "containerservice": {},
+            "containertask": {}
+        },
+        "basic": {
+            "db": {
+                "Processor": "B_Gen5_1"
+            },
+            "containerhost": {
+                "Processor": "",
+                "MaxCount": 2,
+                "MinCount": 0,
+                "DesiredCount": 1
+            },
+            "containerservice": {},
+            "containertask": {}
+        }
+    },
+    "CertificateBehaviours": {
+        "External": false,
+        "Wildcard": true,
+        "IncludeInHost": {
+            "Product": false,
+            "Segment": false,
+            "Tier": false
+        },
+        "HostParts": [
+            "Host",
+            "Tier",
+            "Component",
+            "Instance",
+            "Version",
+            "Segment",
+            "Environment",
+            "Product"
+        ],
+        "Qualifiers": {
+            "prod": {
+                "IncludeInHost": {
+                    "Environment": false
+                },
+                "IncludeInDomain": {
+                    "Environment": false
+                }
+            }
+        }
+    },
+    "LogFiles": {},
+    "LogFileGroups": {},
+    "LogFileProfiles": {
+        "default": {}
+    },
+    "CORSProfiles": {
+        "S3Write": {
+            "AllowedHeaders": [
+                "Content-Length",
+                "Content-Type",
+                "Content-MD5",
+                "Authorization",
+                "Expect",
+                "x-amz-content-sha256",
+                "x-amz-security-token"
+            ]
+        },
+        "S3Delete": {
+            "AllowedHeaders": [
+                "Content-Length",
+                "Content-Type",
+                "Content-MD5",
+                "Authorization",
+                "Expect",
+                "x-amz-content-sha256",
+                "x-amz-security-token"
+            ]
+        }
+    },
+    "ScriptStores": {},
+    "Bootstraps": {
+        "update-debian": {
+            "Index": 10,
+            "ProtectedSettings": {
+                "exec": {
+                    "Key": "commandToExecute",
+                    "Value": "sudo apt update'"
+                }
+            }
+        },
+        "azcli-debian": {
+            "Index": 15,
+            "ProtectedSettings": {
+                "exec": {
+                    "Key": "commandToExecute",
+                    "Value": "curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash'"
+                }
+            }
+        },
+        "docker-debian": {
+            "Index": 16,
+            "ProtectedSettings": {
+                "exec": {
+                    "Key": "commandToExecute",
+                    "Value": "sudo apt install docker.io -y'"
+                }
+            }
+        },
+        "stage": {
+            "Index": 25,
+            "AutoUpgradeOnMinorVersion": true,
+            "ProtectedSettings": {
+                "exec": {
+                    "Key": "commandToExecute",
+                    "Value": "az storage blob download --connection-string ', parameters('storage'), ' -c ', parameters('container'), ' -n ', parameters('blob'), ' -f ', parameters('file')"
+                },
+                "systemAssignedIdentity": {
+                    "Key": "managedIdentity",
+                    "Value": {}
+                }
+            }
+        },
+        "unzip": {
+            "Index": 30,
+            "ProtectedSettings": {
+                "exec": {
+                    "Key": "commandToExecute",
+                    "Value": "sudo apt install unzip && unzip -DD ', parameters('file'), ' -d .'"
+                }
+            }
+        },
+        "init": {
+            "Index": 100,
+            "Publisher": "Microsoft.Azure.Extensions",
+            "Type": {
+                "Name": "CustomScript",
+                "HandlerVersion": "2.1"
+            },
+            "ProtectedSettings": {
+                "initEncoded": {
+                    "Key": "commandToExecute",
+                    "Value": "chmod 755 ./init.sh && ./init.sh"
+                }
+            }
+        },
+        "timestamp": {
+            "Index": 1000,
+            "Settings": {
+                "addTimestamp": {
+                    "Key": "timestamp",
+                    "Value": "[parameters('timestamp')]"
+                }
+            }
+        }
+    },
+    "BootstrapProfiles": {
+        "default": {
+            "computecluster": {
+                "Bootstraps": [
+                    "update-debian",
+                    "azcli-debian",
+                    "docker-debian",
+                    "stage",
+                    "unzip",
+                    "init",
+                    "timestamp"
+                ]
+            }
+        }
+    },
+    "BaselineProfiles": {
+        "default": {
+            "OpsData": "opsdata",
+            "AppData": "appdata",
+            "Encryption": "cmk",
+            "SSHKey": "ssh",
+            "CDNOriginKey": "oai"
+        }
+    },
+    "LogFilters": {},
+    "VMImageProfiles": {
+        "default": {
+            "bastion": {
+                "Publisher": "Canonical",
+                "Offering": "UbuntuServer",
+                "Image": "18.04-LTS"
+            },
+            "computecluster": {
+                "Publisher": "Canonical",
+                "Offering": "UbuntuServer",
+                "Image": "18.04-LTS"
+            },
+            "containerhost": {
+                "Offering": "linux"
+            },
+            "containerservice": {},
+            "containertask": {}
+        }
+    },
+    "NetworkEndpointGroups": {
+        "compute": {
+            "Services": []
+        },
+        "security": {
+            "Services": []
+        },
+        "configurationMgmt": {
+            "Services": []
+        },
+        "containers": {
+            "Services": []
+        },
+        "serverless": {
+            "Services": []
+        },
+        "logs": {
+            "Services": []
+        },
+        "storage": {
+            "Services": [
+                "Microsoft.Storage"
+            ]
+        }
+    },
+    "PlacementProfiles": {
+        "default": {
+            "default": {
+                "Provider": "azure",
+                "Region": "australiaeast",
+                "DeploymentFramework": "arm"
+            }
+        }
+    },
+    "DeploymentProfiles": {
+        "default": {
+            "Modes": {
+                "*": {}
+            }
+        }
+    },
+    "SkuProfiles": {
+        "default": {
+            "apigateway": {
+                "Name": "Developer"
+            },
+            "bastion": {
+                "Name": "Standard_B1ms",
+                "Tier": "Standard",
+                "Capacity": 0
+            },
+            "computecluster": {
+                "Name": "Standard_B1ms",
+                "Tier": "Standard",
+                "Capacity": 1
+            },
+            "containerhost": {
+                "Name": "P1v2",
+                "Tier": "PremiumV2",
+                "Capacity": 1,
+                "Size": "P1v2",
+                "Family": "Pv2"
+            },
+            "containerservice": {},
+            "containertask": {}
+        }
+    },
+    "Segment": {
+        "Network": {
+            "InternetAccess": true,
+            "Tiers": {
+                "Order": [
+                    "web",
+                    "msg",
+                    "app",
+                    "db",
+                    "dir",
+                    "ana",
+                    "api",
+                    "spare",
+                    "elb",
+                    "ilb",
+                    "spare",
+                    "spare",
+                    "spare",
+                    "spare",
+                    "spare",
+                    "mgmt"
+                ]
+            },
+            "Zones": {
+                "Order": [
+                    "a",
+                    "b",
+                    "spare",
+                    "spare"
+                ]
+            }
+        },
+        "NAT": {
+            "Enabled": true,
+            "MultiAZ": false,
+            "Hosted": true
+        },
+        "Bastion": {
+            "Enabled": true,
+            "Active": false,
+            "IPAddressGroups": []
+        },
+        "S3": {
+            "IncludeTenant": false
+        },
+        "RotateKey": true,
+        "Tiers": {
+            "Order": [
+                "elb",
+                "api",
+                "web",
+                "msg",
+                "dir",
+                "ilb",
+                "app",
+                "db",
+                "ana",
+                "mgmt",
+                "docs",
+                "gbl",
+                "external"
+            ]
+        }
+    }
+}

--- a/azure/inputseeders/azure/masterdata.json
+++ b/azure/inputseeders/azure/masterdata.json
@@ -200,8 +200,7 @@
                                 "Tier": "mgmt",
                                 "Component": "vpcendpoint",
                                 "Version": "",
-                                "Instance": "",
-                                "Destination": "default"
+                                "Instance": ""
                             }
                         }
                     }
@@ -280,10 +279,7 @@
             "computecluster": {
                 "Tier": "Standard",
                 "Replication": "LRS"
-            },
-            "containerhost": {},
-            "containerservice": {},
-            "containertask": {}
+            }
         },
         "Blob": {
             "storageAccount": {
@@ -323,22 +319,17 @@
                 "MaxCount": 2,
                 "MinCount": 1,
                 "DesiredCount": 1
-            },
-            "containerservice": {},
-            "containertask": {}
+            }
         },
         "basic": {
             "db": {
                 "Processor": "B_Gen5_1"
             },
             "containerhost": {
-                "Processor": "",
                 "MaxCount": 2,
                 "MinCount": 0,
                 "DesiredCount": 1
-            },
-            "containerservice": {},
-            "containertask": {}
+            }
         }
     },
     "CertificateBehaviours": {
@@ -514,9 +505,7 @@
             },
             "containerhost": {
                 "Offering": "linux"
-            },
-            "containerservice": {},
-            "containertask": {}
+            }
         }
     },
     "NetworkEndpointGroups": {
@@ -581,9 +570,7 @@
                 "Capacity": 1,
                 "Size": "P1v2",
                 "Family": "Pv2"
-            },
-            "containerservice": {},
-            "containertask": {}
+            }
         }
     },
     "Segment": {
@@ -631,7 +618,7 @@
         "S3": {
             "IncludeTenant": false
         },
-        "RotateKey": true,
+        "RotateKeys": true,
         "Tiers": {
             "Order": [
                 "elb",

--- a/azure/inputseeders/azure/regions.json
+++ b/azure/inputseeders/azure/regions.json
@@ -1,0 +1,735 @@
+{
+    "southcentralus": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "southcentralus",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "brazilsouth": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "brazilsouth",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "eastus": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "eastus",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "eastus2": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "eastus2",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "northcentralus": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "northcentralus",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "northeurope": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "northeurope",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "westeurope": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "westeurope",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "westus": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "westus",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "eastasia": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "eastasia",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "southeastasia": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "southeastasia",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "global": {
+        "Partitian": "azure",
+        "Locality": "none",
+        "Zones": {
+            "a": {
+                "Title": "Global",
+                "Description": "A Global Zone",
+                "AzureId": "global",
+                "NetworkEndpoints": []
+            }
+        },
+        "Accounts": {}
+    },
+    "centralus": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "centralus",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "japanwest": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "japanwest",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "japaneast": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "japaneast",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "australiaeast": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "australiaeast",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "australiasoutheast": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "australiasoutheast",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "southindia": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "southindia",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "centralindia": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "centralindia",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "westindia": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "westindia",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "canadaeast": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "canadaeast",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "canadacentral": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "canadacentral",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "uksouth": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "uksouth",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "ukwest": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "ukwest",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "westcentralus": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "westcentralus",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "westus2": {
+        "Partitian": "azure",
+        "Locality": "Americas",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "westus2",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "koreacentral": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "koreacentral",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "koreasouth": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "koreasouth",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "francecentral": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "francecentral",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "francesouth": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "francesouth",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "australiacentral": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "australiacentral",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "australiacentral2": {
+        "Partitian": "azure",
+        "Locality": "Asia Pacific",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "australiacentral2",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "uaecentral": {
+        "Partitian": "azure",
+        "Locality": "Middle East and Africa",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "uaecentral",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "uaenorth": {
+        "Partitian": "azure",
+        "Locality": "Middle East and Africa",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "uaenorth",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "southafricanorth": {
+        "Partitian": "azure",
+        "Locality": "Middle East and Africa",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "southafricanorth",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "southafricawest": {
+        "Partitian": "azure",
+        "Locality": "Middle East and Africa",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "southafricawest",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "switzerlandnorth": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "switzerlandnorth",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "switzerlandwest": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "switzerlandwest",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "germanynorth": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "germanynorth",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "germanywestcentral": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "germanywestcentral",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "norwaywest": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "norwaywest",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    },
+    "norwayeast": {
+        "Partitian": "azure",
+        "Locality": "Europe",
+        "Zones": {
+            "a": {
+                "Title": "Zone A",
+                "Description": "Zone A",
+                "AzureId": "norwayeast",
+                "NetworkEndpoints": [
+                    {
+                        "Type": "Interface",
+                        "ServiceName": "Microsoft.Storage"
+                    }
+                ]
+            }
+        },
+        "Accounts": {}
+    }
+}

--- a/azure/inputseeders/azure/regions.json
+++ b/azure/inputseeders/azure/regions.json
@@ -1,6 +1,6 @@
 {
     "southcentralus": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -18,7 +18,7 @@
         "Accounts": {}
     },
     "brazilsouth": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -36,7 +36,7 @@
         "Accounts": {}
     },
     "eastus": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -54,7 +54,7 @@
         "Accounts": {}
     },
     "eastus2": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -72,7 +72,7 @@
         "Accounts": {}
     },
     "northcentralus": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -90,7 +90,7 @@
         "Accounts": {}
     },
     "northeurope": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -108,7 +108,7 @@
         "Accounts": {}
     },
     "westeurope": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -126,7 +126,7 @@
         "Accounts": {}
     },
     "westus": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -144,7 +144,7 @@
         "Accounts": {}
     },
     "eastasia": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -162,7 +162,7 @@
         "Accounts": {}
     },
     "southeastasia": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -180,7 +180,7 @@
         "Accounts": {}
     },
     "global": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "none",
         "Zones": {
             "a": {
@@ -193,7 +193,7 @@
         "Accounts": {}
     },
     "centralus": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -211,7 +211,7 @@
         "Accounts": {}
     },
     "japanwest": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -229,7 +229,7 @@
         "Accounts": {}
     },
     "japaneast": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -247,7 +247,7 @@
         "Accounts": {}
     },
     "australiaeast": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -265,7 +265,7 @@
         "Accounts": {}
     },
     "australiasoutheast": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -283,7 +283,7 @@
         "Accounts": {}
     },
     "southindia": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -301,7 +301,7 @@
         "Accounts": {}
     },
     "centralindia": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -319,7 +319,7 @@
         "Accounts": {}
     },
     "westindia": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -337,7 +337,7 @@
         "Accounts": {}
     },
     "canadaeast": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -355,7 +355,7 @@
         "Accounts": {}
     },
     "canadacentral": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -373,7 +373,7 @@
         "Accounts": {}
     },
     "uksouth": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -391,7 +391,7 @@
         "Accounts": {}
     },
     "ukwest": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -409,7 +409,7 @@
         "Accounts": {}
     },
     "westcentralus": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -427,7 +427,7 @@
         "Accounts": {}
     },
     "westus2": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Americas",
         "Zones": {
             "a": {
@@ -445,7 +445,7 @@
         "Accounts": {}
     },
     "koreacentral": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -463,7 +463,7 @@
         "Accounts": {}
     },
     "koreasouth": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -481,7 +481,7 @@
         "Accounts": {}
     },
     "francecentral": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -499,7 +499,7 @@
         "Accounts": {}
     },
     "francesouth": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -517,7 +517,7 @@
         "Accounts": {}
     },
     "australiacentral": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -535,7 +535,7 @@
         "Accounts": {}
     },
     "australiacentral2": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Asia Pacific",
         "Zones": {
             "a": {
@@ -553,7 +553,7 @@
         "Accounts": {}
     },
     "uaecentral": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Middle East and Africa",
         "Zones": {
             "a": {
@@ -571,7 +571,7 @@
         "Accounts": {}
     },
     "uaenorth": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Middle East and Africa",
         "Zones": {
             "a": {
@@ -589,7 +589,7 @@
         "Accounts": {}
     },
     "southafricanorth": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Middle East and Africa",
         "Zones": {
             "a": {
@@ -607,7 +607,7 @@
         "Accounts": {}
     },
     "southafricawest": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Middle East and Africa",
         "Zones": {
             "a": {
@@ -625,7 +625,7 @@
         "Accounts": {}
     },
     "switzerlandnorth": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -643,7 +643,7 @@
         "Accounts": {}
     },
     "switzerlandwest": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -661,7 +661,7 @@
         "Accounts": {}
     },
     "germanynorth": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -679,7 +679,7 @@
         "Accounts": {}
     },
     "germanywestcentral": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -697,7 +697,7 @@
         "Accounts": {}
     },
     "norwaywest": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {
@@ -715,7 +715,7 @@
         "Accounts": {}
     },
     "norwayeast": {
-        "Partitian": "azure",
+        "Partition": "azure",
         "Locality": "Europe",
         "Zones": {
             "a": {

--- a/azure/inputseeders/inputseeder.ftl
+++ b/azure/inputseeders/inputseeder.ftl
@@ -1,0 +1,3 @@
+[#ftl]
+
+[#assign AZURE_INPUT_SEEDER = AZURE_PROVIDER ]


### PR DESCRIPTION
## Description
Add basic input seeder support for azure.

## Motivation and Context
This change introduces the seeder support needed to use the azure plugin with the refactored input source processing.

It doesn't replace any existing processing in order to stagger the changes needed to transition to the new input approach.


## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
 - [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
