### PR TITLE
fix: move mock input types into azure provider

### DIFF
--- a/azure/inputsources/mock/commandlineoption.ftl
+++ b/azure/inputsources/mock/commandlineoption.ftl
@@ -1,7 +1,29 @@
 [#ftl]
+
+[#-- Globals to ensure consistency across input type --]
 [#assign AZURE_REGION_MOCK_VALUE = "westus" ]
 [#assign AZURE_SUBSCRIPTION_MOCK_VALUE = "0123456789" ]
 [#assign AZURE_RESOURCEGROUP_MOCK_VALUE = "mockRG" ]
+[#assign AZURE_SERVICE_NAME_MOCK_VALUE = "Microsoft.Mock" ]
+[#assign AZURE_RESOURCE_TYPE_MOCK_VALUE = "mockResourceType" ]
+[#assign AZURE_RESOURCE_NAME_MOCK_VALUE = "mockName" ]
+[#assign AZURE_RESOURCE_ID_MOCK_VALUE = 
+    formatPath(
+        true, 
+        [
+            "subscriptions", 
+            AZURE_SUBSCRIPTION_MOCK_VALUE, 
+            "resourceGroups", 
+            AZURE_RESOURCEGROUP_MOCK_VALUE, 
+            "providers", 
+            AZURE_SERVICE_NAME_MOCK_VALUE, 
+            AZURE_RESOURCE_TYPE_MOCK_VALUE, 
+            AZURE_RESOURCE_NAME_MOCK_VALUE
+        ] 
+    )]
+[#assign AZURE_RESOURCE_URL_MOCK_VALUE = "https://mock.local/" ]
+[#assign AZURE_RESOURCE_IP_ADDRESS_MOCK_VALUE = "123.123.123.123" ]
+[#assign AZURE_BUILD_COMMIT_MOCK_VALUE = "123456789#MockCommit#" ]
 
 [#macro azure_input_mock_commandlineoption_seed]
 

--- a/azuretest/provider.ftl
+++ b/azuretest/provider.ftl
@@ -13,28 +13,3 @@
 
 --]
 [#assign AZURETEST_PROVIDER = "azuretest" ]
-
-[#-- Globals to ensure consistency across testing provider --]
-[#assign AZURE_REGION_MOCK_VALUE = "westus" ]
-[#assign AZURE_SUBSCRIPTION_MOCK_VALUE = "0123456789" ]
-[#assign AZURE_RESOURCEGROUP_MOCK_VALUE = "mockRG" ]
-[#assign AZURE_SERVICE_NAME_MOCK_VALUE = "Microsoft.Mock" ]
-[#assign AZURE_RESOURCE_TYPE_MOCK_VALUE = "mockResourceType" ]
-[#assign AZURE_RESOURCE_NAME_MOCK_VALUE = "mockName" ]
-[#assign AZURE_RESOURCE_ID_MOCK_VALUE = 
-    formatPath(
-        true, 
-        [
-            "subscriptions", 
-            AZURE_SUBSCRIPTION_MOCK_VALUE, 
-            "resourceGroups", 
-            AZURE_RESOURCEGROUP_MOCK_VALUE, 
-            "providers", 
-            AZURE_SERVICE_NAME_MOCK_VALUE, 
-            AZURE_RESOURCE_TYPE_MOCK_VALUE, 
-            AZURE_RESOURCE_NAME_MOCK_VALUE
-        ] 
-    )]
-[#assign AZURE_RESOURCE_URL_MOCK_VALUE = "https://mock.local/" ]
-[#assign AZURE_RESOURCE_IP_ADDRESS_MOCK_VALUE = "123.123.123.123" ]
-[#assign AZURE_BUILD_COMMIT_MOCK_VALUE = "123456789#MockCommit#" ]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
To ensure consistency for data types when using mocked input sources,
the Azure provider defines a number of global variables formatted
appropriately for that type.

These types are currently defined mostly in the azuretest provider,
as testing is the most-common use-case for using the mock input
source.

This poses a problem for new entrances that may make use of the
mock inputsource, as they will require both azure and azuretest
providers to be loaded.

This change moves the definitions for Mock types into the azure
provider, so they can be used by other entrances for non-testing
capabilities. The result is that in order to use mock, you only
have to load the azure provider, but to perform tests, you must
load both (already a requirement).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
New entrances in development that use the mock type had an unnecessary reliance on loading the "azuretest" provider

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the test suite after changes made.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] None of the above.
