### PR TITLE
Fix - Azure ResourceGroup Outputs

### DIFF
--- a/azure/inputsources/composite/stackoutput.ftl
+++ b/azure/inputsources/composite/stackoutput.ftl
@@ -30,6 +30,9 @@
             [#list propertyValue as outputId, outputValue]
 
               [#switch outputId]
+                [#case "resourceGroup"]
+                  [#local stackOutput += { "ResourceGroup" : outputValue["value"] }]
+                  [#break]
                 [#case "deploymentUnit"]
                   [#local stackOutput += { "DeploymentUnit" : outputValue["value"] }]
                   [#break]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds a missing "ResourceGroup" output to the standard provider outputs
- Moves the "ResourceGroup" naming convention from the Executor into the Engine

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current naming convention for the ResourceGroup is established at template deployment time within the Executor, and its value is a concatenation of various environment variable string values. 

All of the information is available however in the Engine which is where the outputs are assigned. It makes sense for the Engine to be responsible for this assignment, rather than the executor. It is also provider-specific, so moving it out of the Executor is ideal.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Template generation and deployment 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
