### PR TITLE
fix: pseudo stacks

### DIFF
--- a/azure/inputseeders/azure/id.ftl
+++ b/azure/inputseeders/azure/id.ftl
@@ -332,6 +332,7 @@
 [/#function]
 
 [#-- Normalise arm stack files to state point sets --]
+[#-- Note that pseudo stacks use the aws format and are handled via the shared provider --]
 [#function azure_configtransformer_normalise filter state]
 
     [#if filterAttributeContainsValue(filter, "Provider", AZURE_PROVIDER) ]
@@ -397,12 +398,15 @@
             [/#if]
         [/#list]
 
+        [#-- Append so as not to loose previously normalised stack info --]
         [#if stackFiles?has_content]
             [#return
                 addToConfigPipelineClass(
                     state,
                     STATE_CONFIG_INPUT_CLASS,
-                    pointSets
+                    pointSets,
+                    ""
+                    APPEND_COMBINE_BEHAVIOuR
                 )
             ]
         [/#if]

--- a/azure/inputseeders/azure/id.ftl
+++ b/azure/inputseeders/azure/id.ftl
@@ -405,8 +405,8 @@
                     state,
                     STATE_CONFIG_INPUT_CLASS,
                     pointSets,
-                    ""
-                    APPEND_COMBINE_BEHAVIOuR
+                    "",
+                    APPEND_COMBINE_BEHAVIOUR
                 )
             ]
         [/#if]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Ensure Azure specific outputs are appended to any that are already in the state.


## Motivation and Context
With the shared provider looking after pseudo stacks, their content will already be in the state when the Azure normaliser runs.


## How Has This Been Tested?
Local template generation

## Followup Actions
- [x] None
