### PR TITLE
refactor!: SPA to have independant storage account

### DIFF
--- a/azure/components/spa/id.ftl
+++ b/azure/components/spa/id.ftl
@@ -1,7 +1,14 @@
 [#ftl]
 [@addResourceGroupInformation
     type=SPA_COMPONENT_TYPE
-    attributes=[]
+    attributes=[
+      {
+          "Names" : "CORSBehaviours",
+          "Description" : "The CORSBehaviours applied to the Storage Account hosting the SPA",
+          "Types" : ARRAY_OF_STRING_TYPE,
+          "Default" : []
+      }
+    ]
     provider=AZURE_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=

--- a/azure/components/spa/setup.ftl
+++ b/azure/components/spa/setup.ftl
@@ -121,30 +121,4 @@
     /]
   [/#if]
 
-  [#-- invalidate the old cached content on the CDN with an epilogue script --]
-  [#--
-  [#if solution.InvalidateOnUpdate && distributions?has_content]
-    [#local invalidationScript = []]
-    [#list distributions as distribution]
-
-      TODO(rossmurr4y):
-      once the CDN component exists, revisit this and ensure the cached data is invalidated.
-
-    [/#list]
-
-    [#if deploymentSubsetRequired("epilogue", false)]
-      [@addToDefaultBashScriptOutput
-        [
-          "case $\{DEPLOYMENT_OPERATION} in",
-          "  create|update)"
-        ] +
-        invalidationScript +
-        [
-          " ;;",
-          " esac"
-        ]
-      /]
-    [/#if]
-  [/#if]
-  --]
 [/#macro]

--- a/azure/components/spa/state.ftl
+++ b/azure/components/spa/state.ftl
@@ -16,6 +16,21 @@
       "config")]
   [#local configFileName = "config.json" ]
 
+  [#-- SPA's hosted in a Storage Account require a named $web blob container --]
+  [#local storageAccountId = formatResourceId(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, core.Id)]
+  [#local storageAccountName =
+    formatAzureResourceName(
+      formatName(core.ShortName, segmentSeedValue),
+      AZURE_STORAGEACCOUNT_RESOURCE_TYPE
+    )
+  ]
+  [#local blobName = formatAzureResourceName(
+      r"$web",
+      AZURE_BLOBSERVICE_RESOURCE_TYPE,
+      storageAccountName
+    )
+  ]
+
   [#assign componentState =
     {
       "Resources": {
@@ -23,6 +38,16 @@
           "Id": formatResourceId(SPA_COMPONENT_TYPE, core.Id),
           "Deployed": true,
           "Type": SPA_COMPONENT_TYPE
+        },
+        "storageAccount" : {
+            "Id" : storageAccountId,
+            "Name" : storageAccountName,
+            "Type" : AZURE_STORAGEACCOUNT_RESOURCE_TYPE
+        },
+        "blobService" : {
+            "Id" : formatResourceId(AZURE_BLOBSERVICE_RESOURCE_TYPE, core.Id),
+            "Name" : blobName,
+            "Type" : AZURE_BLOBSERVICE_RESOURCE_TYPE
         }
       },
       "Attributes": {

--- a/azure/services/microsoft.storage/resource.ftl
+++ b/azure/services/microsoft.storage/resource.ftl
@@ -193,22 +193,24 @@
     dependsOn=[]]
 
     [#assign CORSRules = []]
-    [#list CORSBehaviours as behaviour]
-        [#assign CORSBehaviour = CORSProfiles[behaviour]]
-        [#if CORSBehaviour?has_content]
-            [#assign CORSRules += [
-                {
-                    "allowedHeaders": CORSBehaviour.AllowedHeaders,
-                    "allowedMethods": CORSBehaviour.AllowedMethods,
-                    "allowedOrigins": CORSBehaviour.AllowedOrigins,
-                    "exposedHeaders": CORSBehaviour.ExposedHeaders,
-                    "maxAgeInSeconds": (CORSBehaviour.MaxAge)?c
-                }
-            ]
+    [#if CORSBehaviours?has_content]
+        [#list asArray(CORSBehaviours) as behaviour]
+            [#assign CORSBehaviour = CORSProfiles[behaviour]]
+            [#if CORSBehaviour?has_content]
+                [#assign CORSRules += [
+                    {
+                        "allowedHeaders": CORSBehaviour.AllowedHeaders,
+                        "allowedMethods": CORSBehaviour.AllowedMethods,
+                        "allowedOrigins": CORSBehaviour.AllowedOrigins,
+                        "exposedHeaders": CORSBehaviour.ExposedHeaders,
+                        "maxAgeInSeconds": (CORSBehaviour.MaxAge)?c
+                    }
+                ]
 
-            ]
-        [/#if]
-    [/#list]
+                ]
+            [/#if]
+        [/#list]
+    [/#if]
 
     [@armResource
         id=id


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
BREAKING CHANGE: As per #246, only 1 SPA per Solution is currently possible in the
Azure provider. This is due to the SPA initially deploying content
into the OpsData databucket. However Azure has some unique req. for
hosting static website content, such as a specific container name of
$web being necessary. As there can only be one container with such a
name per Storage Account, this is a problem.

This refactor implements a unique storage account per SPA deployment-
unit.

Additionally, this removes a previous limitation of SPA's that there
must be at least one existing CDN Route in order to deploy. Such a
requirement posed a chicken-and-egg problem where the CDN Route couldn't
exist without the SPA, and vise versa. Now, the SPA can be deployed
standalone - made public via the Storage Account URL - and after that
the CDN + Route can be deployed.

This PR also sets the Storage Account's BlobService property "static website" value to `true`, something required but only exposed through either the CLI or the GUI.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Closes #246 
Closes #183 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Local template generation and deployment into a clean environment.

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None
