### PR TITLE
Refactor/cdn

### DIFF
--- a/azure/components/baseline/setup.ftl
+++ b/azure/components/baseline/setup.ftl
@@ -66,6 +66,7 @@
     [#local accountName = resources["storageAccount"].Name]
     [#local blobId = resources["blobService"].Id]
     [#local blobName = resources["blobService"].Name]
+    [#local webContainerDefault = resources["webContainerDefault"] ]
     [#local keyvault = resources["keyVault"]]
     [#local keyVaultAccessPolicy = resources["keyVaultAccessPolicy"].Id]
     [#local registries = resources["registries"]]
@@ -137,6 +138,16 @@
         [
           getReference(accountId, accountName)
         ]
+    /]
+
+    [@createBlobServiceContainer
+      id=webContainerDefault.Id
+      name=webContainerDefault.Name
+      publicAccess="None"
+      dependsOn=[
+        getReference(accountId, accountName),
+        getReference(blobId, blobName)
+      ]
     /]
 
     [#-- Create All Registry Containers --]

--- a/azure/components/baseline/state.ftl
+++ b/azure/components/baseline/state.ftl
@@ -26,6 +26,13 @@
     )
   ]
 
+  [#local webContainerDefaultName = 
+    formatAzureResourceName(
+      r"$web",
+      AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE,
+      blobName
+    )]
+
   [#local secretId = formatResourceId(AZURE_KEYVAULT_SECRET_RESOURCE_TYPE, core.Id )]
   [#local secretName = formatSecretName(core.ShortName, "ConnectionKey")]
 
@@ -68,6 +75,11 @@
             "Id" : formatResourceId(AZURE_BLOBSERVICE_RESOURCE_TYPE, core.Id),
             "Name" : blobName,
             "Type" : AZURE_BLOBSERVICE_RESOURCE_TYPE
+        },
+        "webContainerDefault" : {
+            "Id" : formatResourceId(AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, core.Id),
+            "Name" : webContainerDefaultName,
+            "Type" : AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE
         },
         "keyVault" : {
             "Id" : formatResourceId(AZURE_KEYVAULT_RESOURCE_TYPE, core.Id),

--- a/azure/components/baseline/state.ftl
+++ b/azure/components/baseline/state.ftl
@@ -116,23 +116,6 @@
   [#local containerName = formatAzureResourceName(container, AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, blobName)]
   [#local containerId = formatResourceId(AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, core.Id)]
 
-  [#local storageEndpoints =
-    getReference(
-      formatId(
-        storageAccountId,
-        DICTIONARY_ATTRIBUTE_TYPE
-      )
-    )
-  ]
-
-  [#if storageEndpoints?is_string]
-    [#local storageEndpoints = {
-      "blob" : "",
-      "queue" : "",
-      "web" : ""
-    }]
-  [/#if]
-
   [#assign componentState =
     {
       "Resources": {
@@ -147,9 +130,9 @@
         "ACCOUNT_ID" : storageAccountId,
         "ACCOUNT_NAME" : storageAccountName,
         "CONTAINER_NAME" : container,
-        "PRIMARY_ENDPOINT" : contentIfContent(storageEndpoints.blob, ""),
-        "QUEUE_ENDPOINT": contentIfContent(storageEndpoints.queue, ""),
-        "WEB_ENDPOINT": contentIfContent(storageEndpoints.web, "")
+        "PRIMARY_ENDPOINT" : getAzServiceEndpoint(AZURE_STORAGE_SERVICE, "blob", storageAccountName),
+        "QUEUE_ENDPOINT": getAzServiceEndpoint(AZURE_STORAGE_SERVICE, "queue", storageAccountName),
+        "WEB_ENDPOINT": getAzServiceEndpoint(AZURE_STORAGE_SERVICE, "web", storageAccountName)
       },
       "Roles": {
         "Inbound": {},

--- a/azure/components/cdn/state.ftl
+++ b/azure/components/cdn/state.ftl
@@ -16,8 +16,8 @@
 
     [#local wafPolicyId = formatDependentResourceId(AZURE_FRONTDOOR_WAF_POLICY_RESOURCE_TYPE, core.Id)]
     [#local wafPolicyName = formatAzureResourceName(
-        formatName(AZURE_FRONTDOOR_WAF_POLICY_RESOURCE_TYPE, core.Tier, core.Component)
-        getResourceType(frontDoorId)
+        formatName(AZURE_FRONTDOOR_WAF_POLICY_RESOURCE_TYPE, core.ShortName),
+        AZURE_FRONTDOOR_WAF_POLICY_RESOURCE_TYPE
     )]
 
     [#local frontDoorFqdn = formatDomainName(frontDoorName, 'azurefd.net')]

--- a/azure/services/microsoft.network.frontdoor/resource.ftl
+++ b/azure/services/microsoft.network.frontdoor/resource.ftl
@@ -25,6 +25,7 @@
     {
       "apiVersion" : "2019-03-01",
       "type" : "Microsoft.Network/FrontDoorWebApplicationFirewallPolicies",
+      "conditions" : [ "alphanumeric_only" ],
       "outputMappings" : {
         REFERENCE_ATTRIBUTE_TYPE : {
           "Property" : "id"

--- a/azure/services/microsoft.network.frontdoor/resource.ftl
+++ b/azure/services/microsoft.network.frontdoor/resource.ftl
@@ -124,7 +124,8 @@
   path=""
   protocol=""
   intervalInSeconds=""
-  healthProbeMethod=""]
+  healthProbeMethod=""
+  disabled=false]
 
   [#return {} +
     attributeIfContent("name", name) +
@@ -132,7 +133,8 @@
       attributeIfContent("path", path) +
       attributeIfContent("protocol", protocol) +
       numberAttributeIfContent("intervalInSeconds", intervalInSeconds) +
-      attributeIfContent("healthProbeMethod", healthProbeMethod)
+      attributeIfContent("healthProbeMethod", healthProbeMethod) +
+      attributeIfTrue("enabledState", disabled, "Disabled")
     )
   ]
 [/#function]

--- a/azure/services/resource.ftl
+++ b/azure/services/resource.ftl
@@ -433,31 +433,32 @@ id, name, type, location, managedBy, tags, properties.provisioningState --]
 
     [#local endpoints = {}]
     [#switch serviceName]
-        [#case "Microsoft.ContainerRegistry"]
+        [#case "microsoft.containerregistry"]
             [#local endpoints =
                 {
                     "containerRegistry" : "azurecr.io"
                 }
             ]
             [#break]
-        [#case "Microsoft.KeyVault"]
+        [#case "microsoft.keyvault"]
             [#local endpoints =
                 {
-                    "vault" : "vault.azure.net/"
+                    "vault" : "vault.azure.net"
                 }
             ]
             [#break]
-        [#case "Microsoft.Storage"]
+        [#case "microsoft.storage"]
             [#local endpoints =
                 {
-                    "blob"  : "blob.core.windows.net/",
-                    "dfs"   : "dfs.core.windows.net/",
-                    "file"  : "file.core.windows.net/",
-                    "queue" : "queue.core.windows.net/",
-                    "table" : "table.core.windows.net/",
-                    "web"   : "web.core.windows.net/"
+                    "blob"  : "blob.core.windows.net",
+                    "dfs"   : "dfs.core.windows.net",
+                    "file"  : "file.core.windows.net",
+                    "queue" : "queue.core.windows.net",
+                    "table" : "table.core.windows.net",
+                    "web"   : "web.core.windows.net"
                 }
             ]
+            [#break]
         [#default]
             [@fatal
                 message="Unsupported Azure Endpoint Service specified."
@@ -471,13 +472,8 @@ id, name, type, location, managedBy, tags, properties.provisioningState --]
             /]
     [/#switch]
 
-    [#local endpoint =
-        "https://" +
-        resourceName +
-        extensions?join(".")?ensure_starts_with(".")?ensure_ends_with(".") +
-        endpoints[serviceType]
-    ]
-
+    [#local prefix = resourceName + extensions?join(".") ]
+    [#local endpoint = [ prefix, endpoints[serviceType] ]?join(".") ]
     [#return endpoint]
 
 [/#function]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
Refactor to the CDN, after implementation of #248

- Baseline now creates a storage account container called $web to be used as a "default" container for a CDN when it doesn't yet have an associated SPA configured
- Storage Endpoints now easily obtained via the name of the storage account rather than through state attributes
- CDN can be deployed without configuring an SPA first - this allows for resources to be defined and deployed right away, rather than 1-at-a-time in a strange order
- WAF Policy naming updated to reflect that it is alphanumeric-only

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->

#248 updates the SPA to have unique storage accounts, this updates the CDN to ensure it finds those accounts

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Local template generation and deployment alongside an SPA

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [ ] Requires #248