### PR TITLE
fix: dynamic cmdb loading

### DIFF
--- a/azure/inputseeders/azure/id.ftl
+++ b/azure/inputseeders/azure/id.ftl
@@ -131,18 +131,17 @@
                 azure_cmdb_regions?keys
             )
         ]
-        [#if requiredRegions?has_content]
-            [#local regions = getObjectAttributes(azure_cmdb_regions, requiredRegions) ]
-        [#else]
-            [#local regions = azure_cmdb_regions]
-        [/#if]
         [#return
-            addToConfigPipelineClass(
+            addToConfigPipelineStageCacheForClass(
                 state,
                 BLUEPRINT_CONFIG_INPUT_CLASS,
                 azure_cmdb_masterdata +
                 {
-                    "Regions" : regions
+                    "Regions" :
+                        requiredRegions?has_content?then(
+                            getObjectAttributes(azure_cmdb_regions, requiredRegions),
+                            azure_cmdb_regions
+                        )
                 },
                 MASTERDATA_SHARED_INPUT_STAGE
             )


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Ensure masterdata does not trigger layer attribute failures during intermediate passes of config pipeline processing.

<!--- Describe your changes in detail -->

## Motivation and Context
Testing of cmdb processing showed layer processing was incorrectly reporting missing attributes.


## How Has This Been Tested?
Local template generation. The test suite has also been run

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- Engine - https://github.com/hamlet-io/engine/pull/1663

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

