### PR TITLE
refactor!: remove use of segmentQualifier

### DIFF
--- a/azure/components/apigateway/state.ftl
+++ b/azure/components/apigateway/state.ftl
@@ -60,7 +60,7 @@
     [#local customHostName = "" ]
 
     [#if certificatePresent]
-        [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers)]
+        [#local certificateObject = getCertificateObject(solution.Certificate!"")]
         [#local certificateDomains = getCertificateDomains(certificateObject) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
         [#local hostName = getHostName(certificateObject, occurrence) ]

--- a/azure/components/baseline/setup.ftl
+++ b/azure/components/baseline/setup.ftl
@@ -75,7 +75,7 @@
 
     [#-- storageAccount : Retrieve Certificate Information --]
     [#if solution.Certificate?has_content]
-      [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePortId, sourcePortName) ]
+      [#local certificateObject = getCertificateObject(solution.Certificate) ]
       [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
       [#local fqdn = formatDomainName(hostName, primaryDomainObject)]
     [#else]
@@ -214,7 +214,7 @@
                 id=keyPair.Id
                 name=formatAzureResourceName(
                       keyPair.Name,
-                      AZURE_KEYVAULT_KEY_RESOURCE_TYPE, 
+                      AZURE_KEYVAULT_KEY_RESOURCE_TYPE,
                       keyvault.Name
                     )
                 parentId=keyvault.Id

--- a/azure/components/cdn/state.ftl
+++ b/azure/components/cdn/state.ftl
@@ -23,7 +23,7 @@
     [#local frontDoorFqdn = formatDomainName(frontDoorName, 'azurefd.net')]
 
     [#if isPresent(solution.Certificate) ]
-        [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers) ]
+        [#local certificateObject = getCertificateObject(solution.Certificate) ]
         [#local hostName = getHostName(certificateObject, occurrence) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
         [#local fqdn = formatDomainName(hostName, primaryDomainObject)]

--- a/azure/components/lb/setup.ftl
+++ b/azure/components/lb/setup.ftl
@@ -86,12 +86,7 @@
         [#local portProtocols += [ destinationPort.Protocol]]
 
         [#-- Certificate --]
-        [#local certificateObject = getCertificateObject(
-            subSolution.Certificate,
-            segmentQualifiers,
-            sourcePort.Id!source,
-            sourcePort.Name!source
-        )]
+        [#local certificateObject = getCertificateObject(subSolution.Certificate)]
         [#local hostName = getHostName(certificateObject, subOccurrence)]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject)]
         [#local fqdn = formatDomainName(hostName, primaryDomainObject)]

--- a/azure/components/lb/state.ftl
+++ b/azure/components/lb/state.ftl
@@ -130,7 +130,7 @@
 
     [#local domainRedirectRules = {} ]
     [#if (sourcePort.Certificate)!false ]
-        [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePortId, sourcePortName)]
+        [#local certificateObject = getCertificateObject(solution.Certificate)]
 
         [#local hostName = getHostName(certificateObject, occurrence)]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject)]

--- a/azure/components/s3/setup.ftl
+++ b/azure/components/s3/setup.ftl
@@ -43,7 +43,7 @@
 
     [#-- Retrieve Certificate Information --]
     [#if solution.Certificate?has_content]
-        [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePortId, sourcePortName) ]
+        [#local certificateObject = getCertificateObject(solution.Certificate) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
         [#local fqdn = formatDomainName(hostName, primaryDomainObject)]
     [#else]


### PR DESCRIPTION
## Intent of Change
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
Remove all usage of the `segmentQualifier` global variable.

## Motivation and Context
With input pipeline processing performing qualification, there is no longer a need for component code to explicitly handle qualification.

BREAKING CHANGE: Move any LB port specific certificate configuration to the affected port configuration rather than qualifying it at the LB level.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1695

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- Refactor solutions to place port specific certificate configuration on load balancers on the individual ports rather than using port qualifiers on the LB level certificate object.

