### PR TITLE
refactor(network)!: refactor network setup process

### DIFF
--- a/azure/components/network/setup.ftl
+++ b/azure/components/network/setup.ftl
@@ -15,84 +15,11 @@
   [#local vnetCIDR = resources["vnet"].Address]
   [#local flowlogs = resources["flowlogs"]!{}]
 
+  [#local vnetDependencies = []]
+
   [#if deploymentSubsetRequired(NETWORK_COMPONENT_TYPE, true)]
 
-    [#-- 1. Vnet --]
-    [@createVNet
-      id=vnetId
-      name=vnetName
-      location=getRegion()
-      addressSpacePrefixes=[vnetCIDR]
-    /]
-
-    [#-- 2. NetworkSecurityGroup --]
-    [#local networkSecurityGroupId = resources["networkSecurityGroup"].Id]
-    [#local networkSecurityGroupName = resources["networkSecurityGroup"].Name]
-
-    [@createNetworkSecurityGroup
-      id=networkSecurityGroupId
-      name=networkSecurityGroupName
-      location=getRegion()
-    /]
-
-    [#-- Seperate NSG for the ELB Subnet                                              --]
-    [#-- Application Gateways have some very specific requirements around NSG         --]
-    [#-- rules that must be in place. At present time they are overly-open in         --]
-    [#-- the access that they grant. To reduce this, the ELB subnet which will        --]
-    [#-- be used by the App Gateways will get their own NSG. This can be              --]
-    [#-- removed once the NSG Rules can be associated with the Azure Service          --]
-    [#-- tag "GatewayManager" https://github.com/MicrosoftDocs/azure-docs/issues/38691--]
-    [#if (resources["subnets"]["elb"]!{})?has_content]
-
-      [#if resources["elbNSG"]?has_content]
-        [#local elbNSG = resources["elbNSG"]]
-      [/#if]
-
-      [@createNetworkSecurityGroup
-        id=elbNSG.Id
-        name=elbNSG.Name
-        location=getRegion()
-      /]
-
-      [@createNetworkSecurityGroupSecurityRule
-        id=formatDependentSecurityRuleId("elb", "AllowGatewayManager")
-        name=formatAzureResourceName(
-                formatName("elb", "AllowGatewayManager"),
-                AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE,
-                elbNSG.Name)
-        description="Grants the GatewayManager access to App Gateway resources"
-        destinationPortProfileName="gatewaymanager"
-        sourceAddressPrefix="*"
-        destinationAddressPrefix="*"
-        access="allow"
-        priority=100
-        direction="Inbound"
-        dependsOn=
-          [
-            elbNSG.Reference
-          ]
-      /]
-
-      [@createNetworkSecurityGroupSecurityRule
-        id=formatDependentSecurityRuleId("elb", "AllowAzureLoadBalancer")
-        name=formatAzureResourceName(
-                formatName("elb", "AllowAzureLoadBalancer"),
-                AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE,
-                elbNSG.Name)
-        description="Grants the GatewayManager access to App Gateway resources"
-        destinationPortProfileName="any"
-        sourceAddressPrefix="AzureLoadBalancer"
-        destinationAddressPrefix="*"
-        access="allow"
-        priority=110
-        direction="Inbound"
-        dependsOn=
-          [
-            elbNSG.Reference
-          ]
-      /]
-
-    [/#if]
+    [#local vnetSubnets = []]
 
     [#-- 3. Subnets for every tier --]
     [#if (resources["subnets"]!{})?has_content]
@@ -121,34 +48,12 @@
         [/#if]
 
         [#local routeTableLink = getLinkTarget(occurrence, networkLink + { "RouteTable" : routeTableId }, false)]
+        [#local routeTableResource = (routeTableLink.State.Resources["routeTable"])!{}]
+
         [#local networkACLLink = getLinkTarget(occurrence, networkLink + { "NetworkACL" : networkACLId }, false)]
-        [#local routeTableResource = routeTableLink.State.Resources["routeTable"]!{}]
+        [#local networkACLResource = (networkACLLink.State.Resources["networkSecurityGroup"])!{}]
 
         [#local subnet = subnets.subnet]
-        [#local subnetIndex = subnets?index]
-        [#local subnetName = formatAzureResourceName(
-          subnet.Name,
-          getResourceType(subnet.Id),
-          vnetName)]
-
-        [#-- Determine dependencies --]
-        [#local dependencies = [
-            getReference(vnetId, vnetName)
-        ]]
-
-        [#if subnetIndex > 0]
-          [#local previousSubnet = resources["subnets"]?values[subnetIndex - 1].subnet]
-          [#local dependencies += [
-            getReference(
-              previousSubnet.Id,
-              formatAzureResourceName(
-                previousSubnet.Name,
-                AZURE_SUBNET_RESOURCE_TYPE,
-                vnetName
-              )
-            )
-          ]]
-        [/#if]
 
         [#-- Retrieve the NetworkEndpoint's from the Gateway component and prepare the Management Tier subnet for them --]
         [#local networkEndpointGroups = []]
@@ -191,89 +96,43 @@
 
         [#-- Add routeTable details if applicable --]
         [#if routeTableResource?has_content]
-          [#local dependencies += [getReference(routeTableResource)]]
+          [#local vnetDependencies += [getReference(routeTableResource)]]
         [/#if]
 
-        [#if networkTier.Name == "elb"]
-          [#local networkSecurityGroupReference = getSubResourceReference(elbNSG.Reference)]
-          [#local dependencies += [elbNSG.Reference]]
-        [#else]
-          [#local networkSecurityGroupReference = getSubResourceReference(
-            getReference(networkSecurityGroupId, networkSecurityGroupName)
-          )]
+        [#if networkACLResource?has_content ]
+          [#local vnetDependencies += [ getReference(networkACLResource)]]
         [/#if]
 
-        [@createSubnet
-          id=subnet.Id
-          name=subnetName
-          addressPrefix=subnet.Address
-          networkSecurityGroup=networkSecurityGroupReference
-          routeTable={} + routeTableResource?has_content?then(
-            getSubResourceReference(getReference(routeTableResource)),
-            {}
+        [#local vnetSubnets += [
+          getVnetSubnet(
+            subnet.Id,
+            subnet.Name,
+            subnet.Address,
+            [],
+            {} + networkACLResource?has_content?then(
+                  getSubResourceReference(getReference(networkACLResource)),
+                  {}
+            ),
+            {} + routeTableResource?has_content?then(
+                  getSubResourceReference(getReference(routeTableResource)),
+                  {}
+            ),
+            ""
+            serviceEndpoints
           )
-          serviceEndpoints=serviceEndpoints
-          dependsOn=dependencies
-        /]
-
-        [#local networkACLConfiguration = networkACLLink.Configuration.Solution]
-
-        [#list networkACLConfiguration.Rules as ruleId, ruleConfig]
-
-          [#--
-            Rules are Subnet-specific.
-            Where an IPAddressGroup is found to be _localnet, use the subnet CIDR instead.
-          --]
-          [#if ruleConfig.Source.IPAddressGroups?seq_contains("_localnet")]
-            [#local direction = "Outbound"]
-            [#local sourceAddressPrefix = subnet.Address]
-          [#else]
-            [#local direction = "Inbound"]
-            [#local sourceAddressPrefix = getGroupCIDRs(
-              ruleConfig.Source.IPAddressGroups,
-              true,
-              occurrence)[0]]
-          [/#if]
-
-          [#if ruleConfig.Destination.IPAddressGroups?seq_contains("_localnet")]
-            [#local destinationAddressPrefix = subnet.Address]
-          [#else]
-            [#local destinationAddressPrefix = getGroupCIDRs(
-              ruleConfig.Destination.IPAddressGroups,
-              true,
-              occurrence)[0]]
-          [/#if]
-
-          [#if subnet.Name == "elb"]
-            [#local nsgName = elbNSG.Name]
-            [#local nsgId = elbNSG.Id]
-          [#else]
-            [#local nsgName = networkSecurityGroupName]
-            [#local nsgId = networkSecurityGroupId]
-          [/#if]
-
-          [@createNetworkSecurityGroupSecurityRule
-            id=formatDependentSecurityRuleId(subnet.Id, ruleId)
-            name=formatAzureResourceName(
-              formatName(tierId,ruleId),
-              getResourceType(formatDependentSecurityRuleId(vnetId, formatName(tierId,ruleId))),
-              nsgName)
-            description=description
-            destinationPortProfileName=ruleConfig.Destination.Port
-            sourceAddressPrefix=sourceAddressPrefix
-            destinationAddressPrefix=destinationAddressPrefix
-            access=ruleConfig.Action
-            priority=(ruleConfig.Priority + tierId?index + ruleId?index)
-            direction=direction
-            dependsOn=
-              [
-                getReference(nsgId, nsgName)
-              ]
-          /]
-
-        [/#list]
+        ]]
       [/#list]
     [/#if]
+
+    [#-- 1. Vnet --]
+    [@createVNet
+      id=vnetId
+      name=vnetName
+      location=getRegion()
+      addressSpacePrefixes=[vnetCIDR]
+      subnets=vnetSubnets
+      dependsOn=vnetDependencies
+    /]
 
     [#-- Sub Components --]
     [#list occurrence.Occurrences![] as subOccurrence]
@@ -284,19 +143,76 @@
 
       [@debug message="Suboccurrence" context=subOccurrence enabled=false /]
 
-      [#-- 4. RouteTables --]
-      [#if core.Type == NETWORK_ROUTE_TABLE_COMPONENT_TYPE &&
-        core.SubComponent.Name != "default"]
+      [#switch core.Type]
+        [#case NETWORK_ROUTE_TABLE_COMPONENT_TYPE]
+          [#if ! resources["routeTable"]?? ]
+            [#continue]
+          [/#if]
 
-        [#local routeTable = resources["routeTable"]]
+          [#local routeTable = resources["routeTable"]]
 
-        [@createRouteTable
-          id=routeTable.Id
-          name=routeTable.Name
-          location=getRegion()
-        /]
+          [@createRouteTable
+            id=routeTable.Id
+            name=routeTable.Name
+            location=getRegion()
+          /]
+          [#break]
 
-      [/#if]
+        [#case NETWORK_ACL_COMPONENT_TYPE ]
+          [#if ! resources["networkSecurityGroup"]?? ]
+            [#continue]
+          [/#if]
+
+          [#local nsg = resources["networkSecurityGroup"]]
+
+          [@createNetworkSecurityGroup
+            id=nsg.Id
+            name=nsg.Name
+            location=getRegion()
+          /]
+
+          [#list solution.Rules as ruleId, ruleConfig]
+
+            [#if ruleConfig.Source.IPAddressGroups?seq_contains("_localnet")
+                  || ruleConfig.Source.IPAddressGroups?seq_contains("__localnet")
+                  || ruleConfig.Source.IPAddressGroups?seq_contains("_named:VirtualNetwork")
+                  || ruleConfig.Source.IPAddressGroups?seq_contains("__named:VirtualNetwork")]
+              [#local direction = "Outbound"]
+            [/#if]
+
+            [#if ruleConfig.Destination.IPAddressGroups?seq_contains("_localnet")
+                  || ruleConfig.Destination.IPAddressGroups?seq_contains("__localnet")
+                  || ruleConfig.Destination.IPAddressGroups?seq_contains("_named:VirtualNetwork")
+                  || ruleConfig.Destination.IPAddressGroups?seq_contains("__named:VirtualNetwork")]
+              [#local direction = "Inbound"]
+            [/#if]
+
+            [@createNetworkSecurityGroupSecurityRuleWithIPAddressGroup
+              id=formatDependentSecurityRuleId(nsg.Id, ruleId)
+              name=formatAzureResourceName(
+                      formatName(ruleId),
+                      getResourceType(
+                        formatDependentSecurityRuleId(vnetId, formatName(nsg.Name,ruleId))
+                      ),
+                      nsg.Name
+              )
+              occurrence=subOccurrence
+              description=description
+              destinationPortProfileName=ruleConfig.Destination.Port
+              sourceIPAddressGroups=ruleConfig.Source.IPAddressGroups
+              destinationIPAdressGroups=ruleConfig.Destination.IPAddressGroups
+              access=ruleConfig.Action
+              priority=ruleConfig.Priority
+              direction=direction
+              dependsOn=
+                [
+                  getReference(nsg.Id, nsg.Name)
+                ]
+            /]
+
+          [/#list]
+          [#break]
+      [/#switch]
     [/#list]
 
     [#-- 6. NetworkWatcher : Flow Logs --]

--- a/azure/components/network/setup.ftl
+++ b/azure/components/network/setup.ftl
@@ -164,6 +164,7 @@
           [/#if]
 
           [#local nsg = resources["networkSecurityGroup"]]
+          [#local flowlogs = (resources["flowLogs"])!{}]
 
           [@createNetworkSecurityGroup
             id=nsg.Id
@@ -209,31 +210,29 @@
                   getReference(nsg.Id, nsg.Name)
                 ]
             /]
-
           [/#list]
-          [#break]
+
+          [#-- NetworkWatcher : Flow Logs --]
+          [#list flowlogs?values as flowlog]
+            [@createNetworkWatcherFlowLog
+              id=flowlog.Id
+              name=flowlog.Name
+              targetResourceId=nsg.Reference
+              storageId=flowlog.StorageId
+              trafficAnalyticsInterval="0"
+              retentionPolicyEnabled=true
+              retentionDays="7"
+              formatType="JSON"
+              formatVersion="0"
+              dependsOn=
+                [
+                  getReference(flowlog.StorageId)
+                ]
+            /]
+          [/#list]
+
+        [#break]
       [/#switch]
     [/#list]
-
-    [#-- 6. NetworkWatcher : Flow Logs --]
-    [#if flowlogs?has_content]
-      [#list flowlogs?values as flowlog]
-        [@createNetworkWatcherFlowLog
-          id=flowlog.Id
-          name=flowlog.Name
-          targetResourceId=getReference(networkSecurityGroupId)
-          storageId=flowlog.StorageId
-          trafficAnalyticsInterval="0"
-          retentionPolicyEnabled=true
-          retentionDays="7"
-          formatType="JSON"
-          formatVersion="0"
-          dependsOn=
-            [
-              getReference(flowlog.StorageId)
-            ]
-        /]
-      [/#list]
-    [/#if]
   [/#if]
 [/#macro]

--- a/azure/components/network/setup.ftl
+++ b/azure/components/network/setup.ftl
@@ -174,18 +174,26 @@
 
           [#list solution.Rules as ruleId, ruleConfig]
 
-            [#if ruleConfig.Source.IPAddressGroups?seq_contains("_localnet")
-                  || ruleConfig.Source.IPAddressGroups?seq_contains("__localnet")
-                  || ruleConfig.Source.IPAddressGroups?seq_contains("_named:VirtualNetwork")
-                  || ruleConfig.Source.IPAddressGroups?seq_contains("__named:VirtualNetwork")]
+            [#local sourceIPAddressGroups = ruleConfig.Source.IPAddressGroups]
+            [#local destinationIPAdressGroups = ruleConfig.Destination.IPAddressGroups ]
+
+            [#if sourceIPAddressGroups?seq_contains("_localnet")
+                  || sourceIPAddressGroups?seq_contains("__localnet")
+                  || sourceIPAddressGroups?seq_contains("_named:VirtualNetwork")
+                  || sourceIPAddressGroups?seq_contains("__named:VirtualNetwork")]
               [#local direction = "Outbound"]
             [/#if]
 
-            [#if ruleConfig.Destination.IPAddressGroups?seq_contains("_localnet")
-                  || ruleConfig.Destination.IPAddressGroups?seq_contains("__localnet")
-                  || ruleConfig.Destination.IPAddressGroups?seq_contains("_named:VirtualNetwork")
-                  || ruleConfig.Destination.IPAddressGroups?seq_contains("__named:VirtualNetwork")]
+            [#if destinationIPAdressGroups?seq_contains("_localnet")
+                  || destinationIPAdressGroups?seq_contains("__localnet")
+                  || destinationIPAdressGroups?seq_contains("_named:VirtualNetwork")
+                  || destinationIPAdressGroups?seq_contains("__named:VirtualNetwork")]
               [#local direction = "Inbound"]
+            [/#if]
+
+            [#if ! ruleConfig.Destination.IPAddressGroups?has_content ]
+              [#local direction = "Inbound" ]
+              [#local destinationIPAdressGroups = [ "_named:*" ]]
             [/#if]
 
             [@createNetworkSecurityGroupSecurityRuleWithIPAddressGroup
@@ -200,8 +208,8 @@
               occurrence=subOccurrence
               description=description
               destinationPortProfileName=ruleConfig.Destination.Port
-              sourceIPAddressGroups=ruleConfig.Source.IPAddressGroups
-              destinationIPAdressGroups=ruleConfig.Destination.IPAddressGroups
+              sourceIPAddressGroups=sourceIPAddressGroups
+              destinationIPAdressGroups=destinationIPAdressGroups
               access=ruleConfig.Action
               priority=ruleConfig.Priority
               direction=direction

--- a/azure/inputseeders/azure/masterdata.json
+++ b/azure/inputseeders/azure/masterdata.json
@@ -142,57 +142,204 @@
                         "NetworkACLs": {
                             "Public": {
                                 "Rules": {
-                                    "internetAccess": {
+                                    "InternetAccess": {
                                         "Priority": 200,
                                         "Action": "allow",
                                         "Source": {
                                             "IPAddressGroups": [
-                                                "_localnet"
+                                                "_named:VirtualNetwork"
                                             ]
                                         },
                                         "Destination": {
                                             "IPAddressGroups": [
-                                                "_global"
+                                                "_named:Internet"
                                             ],
                                             "Port": "any"
+                                        }
+                                    },
+                                    "AllowInbound" : {
+                                        "Priority" : 300,
+                                        "Action" : "allow",
+                                        "Source" : {
+                                            "IPAddressGroups" : [
+                                                "_named:Internet"
+                                            ]
                                         },
-                                        "ReturnTraffic": false
+                                        "Destination" : {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ],
+                                            "Port" : "any"
+                                        }
                                     }
                                 }
                             },
                             "Private": {
                                 "Rules": {
-                                    "internetAccess": {
+                                    "InternetAccess": {
                                         "Priority": 200,
                                         "Action": "allow",
                                         "Source": {
                                             "IPAddressGroups": [
-                                                "_localnet"
+                                                "_named:VirtualNetwork"
                                             ]
                                         },
                                         "Destination": {
                                             "IPAddressGroups": [
-                                                "_global"
+                                                "_named:Internet"
                                             ],
                                             "Port": "any"
                                         }
                                     },
-                                    "blockInbound": {
-                                        "Priority": 100,
+                                    "BlockInbound": {
+                                        "Priority": 500,
                                         "Action": "deny",
                                         "Source": {
                                             "IPAddressGroups": [
-                                                "_global"
+                                                "_named:Internet"
                                             ]
                                         },
                                         "Destination": {
                                             "IPAddressGroups": [
-                                                "_localnet"
+                                                "_named:VirtualNetwork"
                                             ],
                                             "Port": "any"
                                         }
                                     }
                                 }
+                            },
+                            "LBPublic" : {
+                                "Rules": {
+                                    "InternetAccess": {
+                                        "Priority": 100,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:Internet"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "AzureLoadBalancerInbound": {
+                                        "Priority": 200,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:AzureLoadBalancer"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "GatewayManagerInbound": {
+                                        "Priority": 201,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:GatewayManager"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "AllowInbound": {
+                                        "Priority": 300,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:Internet"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    }
+                                }
+                            },
+                            "LBPrivate" : {
+                                "Rules": {
+                                    "internetAccess": {
+                                        "Priority": 100,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:Internet"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "AzureLoadBalancerAccess": {
+                                        "Priority": 200,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:AzureLoadBalancer"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "GatewayManagerAccess": {
+                                        "Priority": 201,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:GatewayManager"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "blockInbound": {
+                                        "Priority": 500,
+                                        "Action": "deny",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:Internet"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    }
+                                }
+                            },
+                            "_none" : {
+                                "Description" : "Don't apply an NSG to the subnet"
                             }
                         },
                         "Links": {

--- a/azure/services/microsoft.compute/resource.ftl
+++ b/azure/services/microsoft.compute/resource.ftl
@@ -79,7 +79,8 @@
   id
   name
   primary=false
-  ipConfigurations=[]]
+  ipConfigurations=[]
+  nsgRef=""]
 
   [#return
     {
@@ -88,7 +89,8 @@
       "properties" : {
         "primary" : primary,
         "ipConfigurations" : ipConfigurations
-      }
+      } +
+      attributeIfContent("networkSecurityGroup", nsg, { "id" : nsgRef })
     }
   ]
 

--- a/azure/services/microsoft.network/resource.ftl
+++ b/azure/services/microsoft.network/resource.ftl
@@ -263,8 +263,8 @@
     properties=
       {
         "access" : access?capitalize,
-        "direction" : direction,
-        "protocol" : destinationPortProfile.IPProtocol?replace("all", "*"),
+        "direction" : direction?capitalize,
+        "protocol" : destinationPortProfile.IPProtocol?replace("all", "*")?capitalize,
         "sourcePortRange": sourcePort
       } +
       attributeIfContent("sourceAddressPrefix", sourceAddressPrefix, formatAzureIPAddress(sourceAddressPrefix)) +


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Adds support for named IP Address Groups when creating network security rules - This allows for use of the Azure builtin network prefixes
- Removes creation of explicit elb network NSG and instead replaces it with a generic ACL which can be applied on any subnet
- Moves network acl creation into the subcomponent and treats the subnet level NSG as the hamlet network ACL
- Moves subnet creation into the vNet as sub resources of the vNet instead of top level resources
- Adds support for a _none network ACL to allow for subnets which don't support custom NSGS
- Updates the default Network to align with the changes to network ACLS to include specific ACLS for access from AzureLoadBalancer and GatewayManager
- Refactors bastion and computecluster to work with new NSG layout

## Motivation and Context

- Subnet Migration was motivated by https://github.com/Azure/azure-quickstart-templates/issues/2786 which meant that if you had top level subnet resources in the same incremental deployment as a vNet the vnet would try and destroy the subnets. If they were in use this would cause the vNet deployment to fail and won't allow you to update your vnet unless all vnet attached resources are removed 
- NetworkACL migration aligns with how we handle network ACLS in other providers, the subnet provides coarse grain control and then passes specific access control onto the individual component to handle 
- The network ACL migration then lends to making the ACL's generic for azure specific setups 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine-plugin-azure/pull/282

### Dependent PRs:

- None

### Consumer Actions:

- None

