### PR TITLE
refactor: bastion network access

### DIFF
--- a/azure/services/microsoft.compute/resource.ftl
+++ b/azure/services/microsoft.compute/resource.ftl
@@ -79,7 +79,8 @@
   id
   name
   primary=false
-  ipConfigurations=[]]
+  ipConfigurations=[]
+  nsgRef=""]
 
   [#return
     {
@@ -88,7 +89,8 @@
       "properties" : {
         "primary" : primary,
         "ipConfigurations" : ipConfigurations
-      }
+      } +
+      attributeIfContent("networkSecurityGroup", nsg, { "id" : nsgRef })
     }
   ]
 


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- Updates the bastion setup to manage its own network security group and use a public IP prefix instead of a public IP
- Adds support for network intefaces to assign NSGs
- handles waking up the bastion host when the solution config says it should be active

## Motivation and Context

- Aligns with the changes introduced in https://github.com/hamlet-io/engine-plugin-azure/pull/283 
- Makes it easier to handle access control 
- Removes the need for assigning an extra interface to a instance to get a public IP

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

