### PR TITLE
feat(gateway): support for inside tunnel config

### DIFF
--- a/azure/components/externalnetwork/state.ftl
+++ b/azure/components/externalnetwork/state.ftl
@@ -54,7 +54,7 @@
             [#list solution.Links as id,link]
                 [#if link?is_hash]
 
-                    [#local linkTarget = getLinkTarget(occurrence, link) ]
+                    [#local linkTarget = getLinkTarget(occurrence, link, false) ]
 
                     [@debug message="Link Target" context=linkTarget enabled=false /]
 
@@ -73,8 +73,8 @@
                             [#switch solution.Engine ]
                                 [#case "SiteToSite" ]
 
-                                    [#local localNetworkGatewayId = formatResourceId(AZURE_LOCAL_NETWORK_GATEWAY_RESOURCE_TYPE, core.Name, id )]
-                                    [#local localNetworkGatewayName = formatName(AZURE_LOCAL_NETWORK_GATEWAY_RESOURCE_TYPE, core.Name, id )]
+                                    [#local localNetworkGatewayId = formatResourceId(AZURE_LOCAL_NETWORK_GATEWAY_RESOURCE_TYPE, core.Name, id  )]
+                                    [#local localNetworkGatewayName = formatName(AZURE_LOCAL_NETWORK_GATEWAY_RESOURCE_TYPE, core.Name, id  )]
 
                                     [#local networkConnectionId = formatResourceId(AZURE_CONNECTION_RESOURCE_TYPE, core.Name, id )]
                                     [#local networkConnectionName = formatName(AZURE_CONNECTION_RESOURCE_TYPE, core.Name, id )]
@@ -82,18 +82,22 @@
                                     [#local resources = mergeObjects(
                                         resources,
                                         {
-                                            "localNetworkGateway" : {
-                                                "Id" : localNetworkGatewayId,
-                                                "Name" : localNetworkGatewayName,
-                                                "Type" : AZURE_LOCAL_NETWORK_GATEWAY_RESOURCE_TYPE,
-                                                "Reference" : getReference(localNetworkGatewayId, localNetworkGatewayName)
-                                            },
-                                            "networkConnection" :{
-                                                "Id" : networkConnectionId,
-                                                "Name" : networkConnectionName,
-                                                "Type" : AZURE_CONNECTION_RESOURCE_TYPE,
-                                                "Reference" : getReference(networkConnectionId, networkConnectionName),
-                                                "VirtualNetworkId" : getExistingReference(linkTargetResources["virtualNetworkGateway"].Id)
+                                            "localConnections" : {
+                                                id : {
+                                                    "localNetworkGateway" : {
+                                                        "Id" : localNetworkGatewayId,
+                                                        "Name" : localNetworkGatewayName,
+                                                        "Type" : AZURE_LOCAL_NETWORK_GATEWAY_RESOURCE_TYPE,
+                                                        "Reference" : getReference(localNetworkGatewayId, localNetworkGatewayName)
+                                                    },
+                                                    "networkConnection" :{
+                                                        "Id" : networkConnectionId,
+                                                        "Name" : networkConnectionName,
+                                                        "Type" : AZURE_CONNECTION_RESOURCE_TYPE,
+                                                        "Reference" : getReference(networkConnectionId, networkConnectionName),
+                                                        "VirtualNetworkId" : getExistingReference(linkTargetResources["virtualNetworkGateway"].Id)
+                                                    }
+                                                }
                                             }
                                         }
                                     )]

--- a/azure/components/gateway/state.ftl
+++ b/azure/components/gateway/state.ftl
@@ -75,25 +75,6 @@
       [#local virtualNetworkGatewayId = formatResourceId(AZURE_VIRTUAL_NETWORK_GATEWAY_RESOURCE_TYPE, core.TypedName)]
       [#local virtualNetworkGatewayName = formatName(AZURE_VIRTUAL_NETWORK_GATEWAY_RESOURCE_TYPE, core.TypedName)]
 
-      [#list [ "A", "B" ] as ip ]
-        [#local publicGatewayIPId = formatResourceId(AZURE_PUBLIC_IP_ADDRESS_RESOURCE_TYPE, core.TypedName, ip)]
-        [#local publicGatewayIPName = formatName(AZURE_PUBLIC_IP_ADDRESS_RESOURCE_TYPE, core.TypedName, ip)]
-
-        [#local resources = mergeObjects(
-          resources,
-          {
-            "publicIPs" : {
-              ip : {
-                "Id" : publicGatewayIPId,
-                "Name" : publicGatewayIPName,
-                "Type" : AZURE_PUBLIC_IP_ADDRESS_RESOURCE_TYPE,
-                "Reference" : getReference(publicGatewayIPId, publicGatewayIPName)
-              }
-            }
-          }
-        )]
-      [/#list]
-
       [#local resources +=
         {
           "virtualNetworkGateway" : {
@@ -155,6 +136,24 @@
       [#break]
 
     [#case "private"]
+
+      [#local virtualNetworkGateway = parent.State.Resources["virtualNetworkGateway"]]
+
+      [#local publicGatewayIPId = formatResourceId(AZURE_PUBLIC_IP_ADDRESS_RESOURCE_TYPE, core.TypedName)]
+      [#local publicGatewayIPName = formatName(AZURE_PUBLIC_IP_ADDRESS_RESOURCE_TYPE, core.TypedName)]
+
+      [#local resources = mergeObjects(
+        resources,
+        {
+          "publicIP" : {
+            "Id" : publicGatewayIPId,
+            "Name" : publicGatewayIPName,
+            "Type" : AZURE_PUBLIC_IP_ADDRESS_RESOURCE_TYPE,
+            "Reference" : getReference(publicGatewayIPId, publicGatewayIPName)
+          }
+        }
+      )]
+
       [#break]
 
     [#default]

--- a/azure/services/microsoft.network/resource.ftl
+++ b/azure/services/microsoft.network/resource.ftl
@@ -829,6 +829,49 @@
   /]
 [/#macro]
 
+[#function getAzVirtualNetworkGatewayBgpAddress
+  InsideTunnelLocalIP
+  ipConfigurationName
+  virtualNetworkGatewayRef ]
+
+  [#if ! virtualNetworkGatewayRef?starts_with("[resourceId")]
+    [#local virtualNetworkGatewayRef = "'" + virtualNetworkGatewayRef + "'" ]
+  [#else]
+    [#local virtualNetworkGatewayRef = (virtualNetworkGatewayRef?remove_beginning('['))?remove_ending(']') ]
+  [/#if]
+
+  [#return {
+    "customBgpIpAddresses" : [ InsideTunnelLocalIP],
+    "ipconfigurationId" : "[concat(" + virtualNetworkGatewayRef + ",'" +  formatAbsolutePath("ipConfigurations", ipConfigurationName) + "')]"
+  }]
+[/#function]
+
+
+[#function getAzVirtualNetworkGatewayIPConfiguration
+    id
+    name
+    publicIPReference
+    subnetReference
+    privateIPAllocationMethod="Dynamic"
+  ]
+
+  [#return
+    {
+      "id" : id,
+      "name" : name,
+      "properties" : {
+        "privateIPAllocationMethod" : privateIPAllocationMethod,
+        "publicIPAddress" : {
+          "id" : publicIPReference
+        },
+        "subnet" : {
+          "id" : subnetReference
+        }
+      }
+    }
+  ]
+[/#function]
+
 
 [#macro createAzVirtualNetworkGateway
   id
@@ -839,31 +882,13 @@
   enableBGP
   asn
   activeActive
-  publicIPReferences
-  subnetReference
+  ipConfigurations
+  bgpPeeringAddresses=[]
   vpnType="RouteBased"
   vpnGatewayGeneration="Generation2"
-  privateIPAllocationMethod="Dynamic"
+
   dependsOn=[]
 ]
-  [#local ipConfigurations = []]
-  [#list publicIPReferences as publicIPReference]
-    [#local ipConfigurations += [
-      {
-        "id" : formatId(id, publicIPReference?index),
-        "name" : formatName(name, publicIPReference?index),
-        "properties" : {
-          "privateIPAllocationMethod" : privateIPAllocationMethod,
-          "publicIPAddress" : {
-            "id" : publicIPReference
-          },
-          "subnet" : {
-            "id" : subnetReference
-          }
-        }
-      }
-    ]]
-  [/#list]
 
   [@armResource
     id=id
@@ -879,7 +904,11 @@
         "enableBgp" : enableBGP,
         "bgpSettings" : {
           "asn" : asn
-        },
+        } +
+        attributeIfContent(
+          "bgpPeeringAddresses",
+          bgpPeeringAddresses
+        ),
         "activeActive" : activeActive,
         "ipConfigurations" : ipConfigurations,
         "sku" : {


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Moves to using destinations on the gateway to define the number of Virtual Network Gateway endpoints are created
- Adds support for defining BGP addresses using the APIPA BGP IP addressing which is required by AWS
- Ensures customer gateways are provisioned if resources aren't available yet

## Motivation and Context

The main part of this change is to make it possible to configure alternate BGP IP addresses including using the APIPA Address approach ( link local in IPv6 ) https://www.geeksforgeeks.org/what-is-apipa-automatic-private-ip-addressing/ 

This is required by AWS BGP configuration when using VPNs. 

To fully support this the Destinations defined on the gateway set how many PUblic IP's are used by the virtual gateway and if it will use Active/Active or Active/Passive 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine-plugin-azure/pull/283

### Dependent PRs:

- None

### Consumer Actions:

- None

