### PR TITLE
feat(directory): Azure AD Directory Services

### DIFF
--- a/azure/components/directory/id.ftl
+++ b/azure/components/directory/id.ftl
@@ -1,0 +1,41 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=DIRECTORY_COMPONENT_TYPE
+    attributes=[
+        {
+            "Names" : "Profiles",
+            "Children" : [
+                {
+                    "Names" : "Sku",
+                    "Types" : STRING_TYPE,
+                    "Default" : "default"
+                }
+            ]
+        }
+    ]
+    provider=AZURE_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AZURE_AAD_SERVICE
+        ]
+/]
+
+
+[@addResourceGroupAttributeValues
+    type=DIRECTORY_COMPONENT_TYPE
+    provider=AZURE_PROVIDER
+    extensions=[
+        {
+            "Names" : "Engine",
+            "Values" : [ "AADDirectoryServices" ],
+            "Default" : "azure:AADDirectoryServices"
+        },
+        {
+            "Names" : "Size",
+            "Values" : ["Sku"],
+            "Default" : [ "azure:Sku" ]
+        }
+    ]
+/]

--- a/azure/components/directory/setup.ftl
+++ b/azure/components/directory/setup.ftl
@@ -1,0 +1,55 @@
+[#ftl]
+[#macro azure_directory_arm_deployment_generationcontract occurrence ]
+    [@addDefaultGenerationContract subsets=[ "template" ] /]
+[/#macro]
+
+[#macro azure_directory_arm_deployment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [@debug message="Entering Bastion Setup" context=occurrence enabled=false /]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+    [#local resources = occurrence.State.Resources]
+
+    [#-- Resources --]
+    [#local directory = resources['directory']]
+
+     [#local sku = getSkuProfile(occurrence, core.Type)]
+
+    [#-- Network Lookups & Links --]
+    [#-- As full subnet name is vnet/subnet, retrieve both & format --]
+    [#local occurrenceNetwork = getOccurrenceNetwork(occurrence)]
+    [#local networkLink = occurrenceNetwork.Link!{} ]
+    [#local networkLinkTarget = getLinkTarget(occurrence, networkLink, false) ]
+
+    [#if ! networkLinkTarget?has_content ]
+        [@fatal message="Network could not be found" context=networkLink /]
+        [#return]
+    [/#if]
+
+    [#local networkResources = networkLinkTarget.State.Resources ]
+    [#local networkVnetResource = networkResources["vnet"]]
+    [#local subnetResource = getSubnet(core.Tier, networkResources)]
+    [#local subnetName = formatAzureResourceName(
+        subnetResource.Name,
+        getResourceType(subnetResource.Id),
+        networkVnetResource.Name
+    )]
+    [#local subnetReference = getReference(subnetResource.Id)]
+
+    [#if deploymentSubsetRequired(DIRECTORY_COMPONENT_TYPE, true)]
+        [@createAzAzureAdDirectoryService
+            id=directory.Id
+            name=directory.Name
+            location=getRegion()
+            sku=sku.Name
+            domainConfigurationType="FullySynced"
+            domainName=directory.DomainName
+            filteredSync="Disabled"
+            subnetReferences=[
+                subnetReference
+            ]
+        /]
+    [/#if]
+
+[/#macro]

--- a/azure/components/directory/state.ftl
+++ b/azure/components/directory/state.ftl
@@ -1,0 +1,36 @@
+[#ftl]
+
+[#macro azure_directory_arm_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local directoryId = formatResourceId(AZURE_AAD_DIRECTORY_SERVICES_RESOURCE_TYPE, core.Id)]
+    [#local directoryName = formatAzureResourceName(core.FullName, getResourceType(directoryId))]
+
+    [#local certificateObject = getCertificateObject(solution.Hostname!"")]
+    [#local certificateDomains = getCertificateDomains(certificateObject) ]
+    [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
+    [#local hostName = getHostName(certificateObject, occurrence) ]
+    [#local fqdn = formatDomainName(hostName, primaryDomainObject) ]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "directory" : {
+                    "Id" : directoryId,
+                    "Name" : directoryName,
+                    "Type" : AZURE_AAD_DIRECTORY_SERVICES_RESOURCE_TYPE,
+                    "Reference" : getReference(directoryId, directoryName),
+                    "DomainName" : fqdn
+                }
+            },
+            "Attributes" : {
+                "DOMAIN_NAME" : fqdn
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/azure/inputseeders/azure/masterdata.json
+++ b/azure/inputseeders/azure/masterdata.json
@@ -174,7 +174,83 @@
                                             "IPAddressGroups": [
                                                 "_global"
                                             ],
+                                            "Port": "gatewaymanager"
+                                        }
+                                    },
+                                    "blockInbound": {
+                                        "Priority": 500,
+                                        "Action": "deny",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:Internet"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ],
                                             "Port": "any"
+                                        }
+                                    }
+                                }
+                            },
+                            "DirectoryPrivate" : {
+                                "Rules": {
+                                    "internetAccess": {
+                                        "Priority": 100,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:Internet"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "AzureLoadBalancerAccess": {
+                                        "Priority": 200,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:AzureLoadBalancer"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups": [
+                                                "_named:VirtualNetwork"
+                                            ],
+                                            "Port": "any"
+                                        }
+                                    },
+                                    "AzureActiveDirectoryDomainServicesAccess": {
+                                        "Priority": 201,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:AzureActiveDirectoryDomainServices"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups" : [],
+                                            "Port": "psremoting_tls"
+                                        }
+                                    },
+                                    "CorpNetSawAccess": {
+                                        "Description" : "Azure AD Support Access",
+                                        "Priority": 202,
+                                        "Action": "allow",
+                                        "Source": {
+                                            "IPAddressGroups": [
+                                                "_named:CorpNetSaw"
+                                            ]
+                                        },
+                                        "Destination": {
+                                            "IPAddressGroups" : [],
+                                            "Port": "rdp_tcp"
                                         }
                                     },
                                     "blockInbound": {
@@ -282,6 +358,24 @@
                 "To": 65535
             },
             "IPProtocol": "all"
+        },
+        "psremoting_tls" : {
+            "Description" : "PowerShell Remoting TLS",
+            "IPProtocol" : "tcp",
+            "Port" : 5986,
+            "Protocol" : "TCP"
+        },
+        "rdp_tcp" : {
+            "Description" : "Remote Desktop Protocol",
+            "IPProtocol" : "tcp",
+            "Port" : 3389,
+            "Protocol" : "TCP"
+        },
+        "rdp_udp" : {
+            "Description" : "Remote Desktop Protocol",
+            "IPProtocol" : "udp",
+            "Port" : 3389,
+            "Protocol" : "UDP"
         }
     },
     "Storage": {
@@ -592,6 +686,9 @@
                 "Name" : "VpnGw2AZ",
                 "Tier" : "VpnGw2AZ",
                 "Generation" : "Generation2"
+            },
+            "directory" : {
+                "Name" : "Standard"
             }
         }
     },

--- a/azure/references/SkuProfile/id.ftl
+++ b/azure/references/SkuProfile/id.ftl
@@ -165,6 +165,15 @@
                     "Types" : STRING_TYPE
                 }
             ]
+        },
+        {
+            "Names" : "directory",
+            "Children" : [
+                {
+                    "Names" : "Name",
+                    "Types" : STRING_TYPE
+                }
+            ]
         }
     ]
 /]

--- a/azure/services/microsoft.aad/id.ftl
+++ b/azure/services/microsoft.aad/id.ftl
@@ -1,0 +1,4 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AZURE_AAD_DIRECTORY_SERVICES_RESOURCE_TYPE = "aadds"]

--- a/azure/services/microsoft.aad/resource.ftl
+++ b/azure/services/microsoft.aad/resource.ftl
@@ -1,0 +1,59 @@
+[#ftl]
+
+[@addResourceProfile
+  service=AZURE_AAD_SERVICE
+  resource=AZURE_AAD_DIRECTORY_SERVICES_RESOURCE_TYPE
+  profile=
+    {
+      "apiVersion" : "2021-05-01",
+      "type" : "Microsoft.AAD/DomainServices",
+      "outputMappings" : {
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
+        }
+      }
+    }
+/]
+
+[#macro createAzAzureAdDirectoryService
+  id
+  name
+  location
+  sku
+  domainConfigurationType
+  domainName
+  filteredSync
+  subnetReferences=[]
+  dependsOn={}]
+
+  [#local replicaSets = subnetReferences?map(x -> { "subnetId" : x, "location" : location }) ]
+
+  [@armResource
+    id=id
+    name=name
+    profile=AZURE_AAD_DIRECTORY_SERVICES_RESOURCE_TYPE
+    location=location
+    dependsOn=dependsOn
+    properties=
+      {
+        "domainConfigurationType" : domainConfigurationType,
+        "domainName" : domainName,
+        "filteredSync" : filteredSync,
+        "replicaSets" : replicaSets,
+        "sku" : sku,
+        "domainSecuritySettings": {
+            "kerberosArmoring": "Disabled",
+            "kerberosRc4Encryption": "Disabled",
+            "ntlmV1": "Disabled",
+            "syncKerberosPasswords": "Enabled",
+            "syncNtlmPasswords": "Disabled",
+            "syncOnPremPasswords": "Disabled",
+            "tlsV1": "Disabled"
+        },
+        "ldapsSettings" : {
+            "externalAccess" : "Disabled"
+        }
+      }
+  /]
+
+[/#macro]

--- a/azure/services/service.ftl
+++ b/azure/services/service.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#-- 
+[#--
     Services are structured within the plugin by their top-level Azure Service Type.
     Where a large resource definition within a given Service warrants being split into
     several files for maintainability, dot-notation will be used.
@@ -9,6 +9,10 @@
 
     ie. "microsoft.network.applicationgateways"
 --]
+
+[#-- Microsoft.AAD --]
+[#assign AZURE_AAD_SERVICE = "microsoft.aad"]
+[@addService provider=AZURE_PROVIDER service=AZURE_AAD_SERVICE /]
 
 [#-- Microsoft.ApiManagement --]
 [#assign AZURE_API_MANAGEMENT_SERVICE = "microsoft.apimanagement"]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for using the directory component to provision a  Azure AD Directory Services instance
- Adds additional subnet level NSGs which add the required rules to have a private AD instance with support from the Azure named prefixes

## Motivation and Context

This allows for using Azure Active Directory groups and users to authenticate with services which support traditional AD services

## How Has This Been Tested?

Tested on local deployment

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine-plugin-azure/pull/283

### Dependent PRs:

- None

### Consumer Actions:

- None

