### PR TITLE
fix(lambda): build settings lookup

### DIFF
--- a/azure/components/lambda/setup.ftl
+++ b/azure/components/lambda/setup.ftl
@@ -115,7 +115,7 @@
                         "functionFiles",
                         "lambda",
                         productName,
-                        occurrence,
+                        subOccurrence,
                         function.Name + ".zip",
                         getReference(function.Id, function.Name, "ResourceGroup")
                     ) +

--- a/azuretest/modules/lambda/module.ftl
+++ b/azuretest/modules/lambda/module.ftl
@@ -15,7 +15,7 @@
             {
                 "Type" : "Builds",
                 "Scope" : "Products",
-                "Namespace" : "mockedup-integration-application-az-lambda-base",
+                "Namespace" : "mockedup-integration-app-lambda-api",
                 "Settings" : {
                     "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
                     "FORMATS" : ["lambda"]
@@ -27,22 +27,17 @@
                 "app" : {
                     "Components" : {
                         "lambda" : {
-                            "lambda" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "application-az-lambda-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "Functions" : {
-                                    "api" : {
-                                        "Handler" : "src/handler.api",
-                                        "RunTime" : "nodejs",
-                                        "Extensions" : [ "_mockext" ],
-                                        "Links" : {}
-                                    }
+                            "Type" : "lambda",
+                            "deployment:Unit" : "application-az-lambda-base",
+                            "Profiles" : {
+                                "Testing" : [ "baselambdatemplate" ]
+                            },
+                            "Functions" : {
+                                "api" : {
+                                    "Handler" : "src/handler.api",
+                                    "RunTime" : "nodejs",
+                                    "Extensions" : [ "_mockext" ],
+                                    "Links" : {}
                                 }
                             }
                         }
@@ -65,7 +60,7 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "baselambdatemplate" : {
                     "lambda" : {
                         "TestCases" : [ "baselambdatemplate" ]
                     }


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Use the subOccurrence properties to determine the build settings instead of the parent

## Motivation and Context

Build settings were failing on lookup

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

