### PR TITLE
refactor: remove mock output service from testing

### DIFF
--- a/azure/components/network/setup.ftl
+++ b/azure/components/network/setup.ftl
@@ -241,7 +241,7 @@
 
             [#switch (storageLink.Core.Type)!"" ]
               [#case S3_COMPONENT_TYPE]
-              [#case BASELINE_DATA_COMPONENT_TYPE]
+              [#case BASELINE_COMPONENT_TYPE]
                 [#break]
 
               [#default]
@@ -259,7 +259,7 @@
               id=flowlog.Id
               name=flowlog.Name
               targetResourceId=nsg.Reference
-              storageId=getReference((storageLink.State.Resources.container)!{})
+              storageId=getReference((storageLink.State.Resources.storageAccount)!{})
               trafficAnalyticsInterval="0"
               retentionPolicyEnabled=true
               retentionDays="7"

--- a/azure/components/network/state.ftl
+++ b/azure/components/network/state.ftl
@@ -159,39 +159,6 @@
     [#list parent.Configuration.Solution.Logging.FlowLogs as id,flowlog]
         [#local flowLogId = formatDependentNetworkWatcherId(nsgId)]
 
-        [#-- default storage --]
-        [#local storageId = getExistingReference(formatResourceId(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, core.Id))]
-
-        [#if flowlog.Prefix??]
-          [@fatal
-            message="Network Watcher FlowLogs do not support a Prefix in Azure at this time."
-            context=flowlog
-          /]
-        [/#if]
-
-        [#if (flowlog.DestinationType!{})?has_content && (flowlog.DestinationType != "s3")]
-          [@fatal
-            message="Invalid flow log destination type. Only s3 is supported."
-            context=flowlog
-          /]
-        [/#if]
-
-        [#-- destination assignment --]
-        [#if flowlog.s3??]
-          [#-- link --]
-          [#if isPresent(flowlog.s3.Link)]
-            [#local flowLogTarget = getLinkTarget(parent, flowlog.s3.Link)]
-            [#if flowLogTarget?has_content]
-              [#local storageId = flowLogTarget]
-            [/#if]
-          [/#if]
-
-          [#-- prefix --]
-          [#if flowlog.s3.Prefix??]
-            [#local prefix = flowlog.s3.Prefix ]
-          [/#if]
-        [/#if]
-
         [#local resources = mergeObjects(
             resources,
             {
@@ -200,8 +167,7 @@
                   "Id" : formatId(AZURE_NETWORK_WATCHER_FLOWLOG_RESOURCE_TYPE, vnet.Id, nsgId, id),
                   "Name" : formatName(core.Name, id, AZURE_NETWORK_WATCHER_FLOWLOG_RESOURCE_TYPE),
                   "Type" : AZURE_NETWORK_WATCHER_FLOWLOG_RESOURCE_TYPE,
-                  "StorageId" : storageId,
-                  "Prefix" : prefix
+                  "StorageLink" : (flowlog.s3.Link)!{}
                 }
               }
             }

--- a/azure/inputseeders/azure/id.ftl
+++ b/azure/inputseeders/azure/id.ftl
@@ -32,11 +32,6 @@
 /]
 
 [@addSeederToStatePipeline
-    stage=FIXTURE_SHARED_INPUT_STAGE
-    seeder=AZURE_INPUT_SEEDER
-/]
-
-[@addSeederToStatePipeline
     stage=SIMULATE_SHARED_INPUT_STAGE
     seeder=AZURE_INPUT_SEEDER
 /]
@@ -171,159 +166,6 @@
                 FIXTURE_SHARED_INPUT_STAGE
             )
         ]
-        [#local result =
-            addToConfigPipelineClass(
-                result,
-                DEFINITIONS_CONFIG_INPUT_CLASS,
-                {
-                    "apiXapigateway" : {
-                        "openapi" : "3.0.1",
-                        "info" : {
-                            "title" : "Hamlet Mock API",
-                            "description" : "API for testing hamlet",
-                            "version" : "1.0"
-                        },
-                        "servers" : [ {
-                            "url" : "https://mock.com"
-                        } ],
-                        "security" : [ {
-                            "apiKeyHeader" : [ ]
-                        }, {
-                            "apiKeyQuery" : [ ]
-                        } ],
-                        "paths" : {
-                            "/mockpath" : {
-                            "post" : {
-                                "summary" : "Mock POST method",
-                                "description" : "mock description",
-                                "operationId" : "mock-example",
-                                "requestBody" : {
-                                    "content" : {
-                                        "application/json" : {
-                                            "schema" : {
-                                                "$ref" : "#/mock/example/ref"
-                                            }
-                                        }
-                                    }
-                                },
-                                "responses" : {
-                                    "200" : {
-                                        "description" : "OK",
-                                        "content" : {
-                                            "application/json" : {
-                                                "schema" : {
-                                                    "$ref" : "#/mock/example/ref"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "401" : {
-                                        "description" : "Auth Failed",
-                                        "content" : {
-                                            "application/json" : {
-                                                "schema" : {
-                                                    "$ref" : "#/mock/example/ref"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "500" : {
-                                        "description" : "Submission failed",
-                                        "content" : {
-                                            "application/json" : {
-                                                "schema" : {
-                                                    "$ref" : "#/mock/example/ref"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "options" : {
-                                "tags" : [ "CORS" ],
-                                "summary" : "CORS support",
-                                "description" : "Enable CORS by returning correct headers\n",
-                                "responses" : {
-                                "200" : {
-                                    "description" : "Default response for CORS method",
-                                    "headers" : {
-                                        "Access-Control-Allow-Origin" : {
-                                            "style" : "simple",
-                                            "explode" : false,
-                                            "schema" : {
-                                                "type" : "string"
-                                            }
-                                        },
-                                        "Access-Control-Allow-Methods" : {
-                                            "style" : "simple",
-                                            "explode" : false,
-                                            "schema" : {
-                                                "type" : "string"
-                                            }
-                                        },
-                                        "Access-Control-Allow-Headers" : {
-                                            "style" : "simple",
-                                            "explode" : false,
-                                            "schema" : {
-                                                "type" : "string"
-                                            }
-                                        }
-                                    },
-                                    "content" : { }
-                                }
-                                }
-                            }
-                            }
-                        },
-                        "components" : {
-                            "schemas" : {
-                                "PostRequest" : {
-                                    "type" : "object",
-                                    "properties" : {
-                                        "id" : {
-                                            "type" : "string",
-                                            "description" : "mock desc"
-                                        }
-                                    }
-                                },
-                                "Post200ApplicationJsonResponse" : {
-                                    "type" : "object",
-                                    "properties" : {
-                                        "message" : {
-                                            "type" : "string",
-                                            "description" : "Success message",
-                                            "example" : "Unauthorized Error"
-                                        }
-                                    }
-                                },
-                                "Post401ApplicationJsonResponse" : {
-                                    "type" : "object",
-                                    "properties" : {
-                                        "message" : {
-                                            "type" : "string",
-                                            "description" : "Auth Failed",
-                                            "example" : "OK"
-                                        }
-                                    }
-                                },
-                                "Post500ApplicationJsonResponse" : {
-                                    "type" : "object",
-                                    "properties" : {
-                                        "message" : {
-                                            "type" : "string",
-                                            "description" : "Submission Failed",
-                                            "example" : "Error"
-                                        }
-                                    }
-                                }
-                            },
-                            "securitySchemes" : {}
-                        }
-                    }
-                },
-                FIXTURE_SHARED_INPUT_STAGE
-            )
-        ]
         [#return result ]
     [/#if]
     [#return state]
@@ -416,43 +258,38 @@
     [#return state]
 [/#function]
 
-[#function azure_stateseeder_fixture filter state]
-
-    [#local id = state.Id]
-
-    [#switch id?split("X")?last ]
-        [#case NAME_ATTRIBUTE_TYPE]
-            [#local value = AZURE_RESOURCE_NAME_MOCK_VALUE]
-            [#break]
-        [#case URL_ATTRIBUTE_TYPE ]
-            [#local value = AZURE_RESOURCE_URL_MOCK_VALUE + id ]
-            [#break]
-        [#case IP_ADDRESS_ATTRIBUTE_TYPE ]
-            [#local value = AZURE_RESOURCE_IP_ADDRESS_MOCK_VALUE ]
-            [#break]
-        [#case REGION_ATTRIBUTE_TYPE ]
-            [#local value = AZURE_REGION_MOCK_VALUE ]
-            [#break]
-        [#default]
-            [#--The default value will be an azure resource Id --]
-            [#local value = AZURE_RESOURCE_ID_MOCK_VALUE]
-            [#break]
-    [/#switch]
-
-    [#return
-        mergeObjects(
-            state,
-            {
-                "Value" : value
-            }
-        )
-    ]
-
-[/#function]
-
 [#function azure_stateseeder_simulate filter state]
     [#if ! state.Value?has_content]
-        [#return azure_stateseeder_fixture(filter, state) ]
+
+        [#local id = state.Id]
+
+        [#switch id?split("X")?last ]
+            [#case NAME_ATTRIBUTE_TYPE]
+                [#local value = AZURE_RESOURCE_NAME_MOCK_VALUE]
+                [#break]
+            [#case URL_ATTRIBUTE_TYPE ]
+                [#local value = AZURE_RESOURCE_URL_MOCK_VALUE + id ]
+                [#break]
+            [#case IP_ADDRESS_ATTRIBUTE_TYPE ]
+                [#local value = AZURE_RESOURCE_IP_ADDRESS_MOCK_VALUE ]
+                [#break]
+            [#case REGION_ATTRIBUTE_TYPE ]
+                [#local value = AZURE_REGION_MOCK_VALUE ]
+                [#break]
+            [#default]
+                [#--The default value will be an azure resource Id --]
+                [#local value = AZURE_RESOURCE_ID_MOCK_VALUE]
+                [#break]
+        [/#switch]
+
+        [#return
+            mergeObjects(
+                state,
+                {
+                    "Value" : value
+                }
+            )
+        ]
     [/#if]
     [#return state]
 [/#function]

--- a/azure/services/microsoft.authorization/policy.ftl
+++ b/azure/services/microsoft.authorization/policy.ftl
@@ -22,7 +22,7 @@
 [#-- through occurrence.State.Resources[<resource>].Reference --]
 [#function getRoleReference role]
     [#local userRole = userRoles[role]]
-    [#return getReference(userRole.Id)]
+    [#return getReference(formatResourceId(AZURE_ROLE_DEFINITION_RESOURCE_TYPE, userRole.Id))]
 [/#function]
 
 [#-- App Registration Endpoints --]

--- a/azure/services/resource.ftl
+++ b/azure/services/resource.ftl
@@ -160,7 +160,11 @@
     [#if ! ((profile!{})?has_content)]
         [@fatal
             message="Could not find the resource type."
-            context={"Id" : id, "Profiles" : azureResourceProfiles}
+            context={
+                "Id" : id,
+                "name": name,
+                "attributeType": attributeType
+            }
         /]
         [#return ""]
     [/#if]

--- a/azuretest/extensions/azure_adaptorbase/extension.ftl
+++ b/azuretest/extensions/azure_adaptorbase/extension.ftl
@@ -1,0 +1,24 @@
+[#ftl]
+
+[@addExtension
+    id="azure_adaptorbase"
+    aliases=[
+        "_azure_adaptorbase"
+    ]
+    description=[
+        "Test extension for adaptor base"
+    ]
+    supportedTypes=[
+        ADAPTOR_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_azure_adaptorbase_deployment_setup occurrence ]
+
+    [@Settings
+        {
+            "Name": occurrence.Core.FullName
+        }
+    /]
+
+[/#macro]

--- a/azuretest/inputseeders/azuretest/id.ftl
+++ b/azuretest/inputseeders/azuretest/id.ftl
@@ -23,6 +23,10 @@
                 },
                 "Product" : {
                     "Modules" : {
+                        "segment": {
+                            "Provider": "azuretest",
+                            "Name": "segment"
+                        },
                         "adaptor" : {
                             "Provider" : "azuretest",
                             "Name" : "adaptor"

--- a/azuretest/modules/adaptor/module.ftl
+++ b/azuretest/modules/adaptor/module.ftl
@@ -14,7 +14,7 @@
             {
                 "Type" : "Builds",
                 "Scope" : "Products",
-                "Namespace" : "mockedup-integration-azure-adaptor-base",
+                "Namespace" : "mockedup-integration-mgmt-adaptorbase",
                 "Settings" : {
                     "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
                     "FORMATS" : ["lambda"]
@@ -25,27 +25,40 @@
             "Tiers" : {
                 "mgmt" : {
                     "Components" : {
-                        "adaptortest" : {
-                            "adaptor" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "azure-adaptor-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "Extensions" : [ "MockFragment" ]
+                        "adaptorbase" : {
+                            "Type": "adaptor",
+                            "deployment:Unit": "azure-adaptor",
+                            "Profiles" : {
+                                "Testing" : "adaptorbase"
+                            },
+                            "Extensions" : [ "_azure_adaptorbase" ]
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "adaptorbase": {
+                    "OutputSuffix" : "config.json",
+                    "Structural" : {
+                        "JSON" : {
+                            "Match" : {
+                                "Name" : {
+                                    "Path" : "NAME",
+                                    "Value" : "mockedup-integration-management-adaptorbase"
+                                }
                             }
                         }
                     }
                 }
             },
-            "TestCases" : {},
-            "TestProfiles" : {}
+            "TestProfiles" : {
+                "adaptorbase": {
+                    "adaptor": {
+                        "TestCases": [ "adaptorbase"]
+                    }
+                }
+            }
         }
-        stackOutputs=[]
-        commandLineOption={}
     /]
 
 [/#macro]

--- a/azuretest/modules/apigateway/module.ftl
+++ b/azuretest/modules/apigateway/module.ftl
@@ -11,7 +11,7 @@
 
     [@loadModule
         definitions={
-            "appXapigateway" : {
+            "apiXapigatewaybase" : {
                 "openapi": "3.0.0",
                 "info": {
                     "version": "1.0.0",
@@ -32,23 +32,11 @@
                 }
             }
         }
-    /]
-
-    [@loadModule
         settingSets=[
-            {
-                "Type" : "Builds",
-                "Scope" : "Products",
-                "Namespace" : "mockedup-integration-application-az-apigateway-base",
-                "Settings" : {
-                    "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
-                    "FORMATS" : ["openapi"]
-                }
-            },
             {
                 "Type" : "Settings",
                 "Scope" : "Products",
-                "Namespace" : "mockedup-integration-application-az-apigateway-base",
+                "Namespace" : "mockedup-integration-api-apigatewaybase",
                 "Settings" : {
                     "apigw": {
                         "Internal": true,
@@ -67,42 +55,37 @@
             "Tiers" : {
                 "api" : {
                     "Components" : {
-                        "apigateway" : {
-                            "apigateway" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "application-az-apigateway-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "Image" : {
-                                    "Source" : "none"
-                                },
-                                "Certificate": {
-                                    "Enabled" : false
-                                },
-                                "Links" : {},
-                                "BasePathBehaviour" : "ignore",
-                                "azure:Contact": {
-                                    "Name" : "Mock Ock",
-                                    "Email": "m.ock@example.com"
-                                }
+                        "apigatewaybase" : {
+                            "Type": "apigateway",
+                            "deployment:Unit": "azure-apigateway",
+                            "Profiles" : {
+                                "Testing" : [ "apigatewaybase" ]
+                            },
+                            "Image" : {
+                                "Source" : "none"
+                            },
+                            "Certificate": {
+                                "Enabled" : false
+                            },
+                            "Links" : {},
+                            "BasePathBehaviour" : "ignore",
+                            "azure:Contact": {
+                                "Name" : "Mock Ock",
+                                "Email": "m.ock@example.com"
                             }
                         }
                     }
                 }
             },
             "TestCases" : {
-                "baseapigatewaytemplate" : {
+                "apigatewaybase" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "APIMID" : {
-                                    "Path" : "outputs.serviceXmockedupXintegrationXapiXapigateway.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Path" : "outputs.serviceXmockedupXintegrationXapiXapigatewaybase.value",
+                                    "Value" : "[resourceId('Microsoft.ApiManagement/service', 'mockedup-integration-api-apigatewaybase-568132487')]"
                                 }
                             }
                         }
@@ -110,9 +93,9 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "apigatewaybase" : {
                     "apigateway" : {
-                        "TestCases" : [ "baseapigatewaytemplate" ]
+                        "TestCases" : [ "apigatewaybase" ]
                     }
                 }
             }

--- a/azuretest/modules/baseline/module.ftl
+++ b/azuretest/modules/baseline/module.ftl
@@ -10,36 +10,30 @@
 [#macro azuretest_module_baseline ]
 
     [@loadModule
-        settingSets=[]
         blueprint={
             "Tiers" : {
                 "mgmt" : {
                     "Components" : {
                         "baseline" : {
-                            "baseline" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "segment-az-baseline-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "azure:AdministratorGroups" : [ "1234567890-1234567890-1234567890-1234567890" ]
-                            }
+                            "Type": "baseline",
+                            "deployment:Unit": "baseline",
+                            "Profiles" : {
+                                "Testing" : [ "baseline" ]
+                            },
+                            "azure:AdministratorGroups" : [ "1234567890-1234567890-1234567890-1234567890" ]
                         }
                     }
                 }
             },
             "TestCases" : {
-                "basebaselinetemplate" : {
+                "baseline" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "BaselineStorageID" : {
                                     "Path" : "outputs.storageXmgmtXbaseline.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Value" : "[resourceId('Microsoft.Storage/storageAccounts', 'mgmtbaseline568132487568')]"
                                 }
                             }
                         }
@@ -47,15 +41,13 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "baseline" : {
                     "baseline" : {
-                        "TestCases" : [ "basebaselinetemplate" ]
+                        "TestCases" : [ "baseline" ]
                     }
                 }
             }
         }
-        stackOutputs=[]
-        commandLineOption={}
     /]
 
 [/#macro]

--- a/azuretest/modules/bastion/module.ftl
+++ b/azuretest/modules/bastion/module.ftl
@@ -16,32 +16,27 @@
             "Tiers" : {
                 "mgmt" : {
                     "Components" : {
-                        "bastion" : {
-                            "bastion" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "segment-az-bastion-base" ]
-                                    }
-                                },
-                                "Enabled" : true,
-                                "MultiAZ": false,
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                }
+                        "bastionbase" : {
+                            "Type": "bastion",
+                            "deployment:Unit": "azure-bastion",
+                            "Active" : true,
+                            "MultiAZ": false,
+                            "Profiles" : {
+                                "Testing" : [ "bastionbase" ]
                             }
                         }
                     }
                 }
             },
             "TestCases" : {
-                "basebastiontemplate" : {
+                "bastionbase" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "ScaleSetID" : {
-                                    "Path" : "outputs.vmssXmanagementXbastionXbastion.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Path" : "outputs.vmssXmanagementXbastionbaseXbastion.value",
+                                    "Value" : "[resourceId('Microsoft.Compute/virtualMachineScaleSets', 'vmss-management-bastionbase-bastion')]"
                                 }
                             }
                         }
@@ -49,9 +44,9 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "bastionbase" : {
                     "bastion" : {
-                        "TestCases" : [ "basebastiontemplate" ]
+                        "TestCases" : [ "bastionbase" ]
                     }
                 }
             }

--- a/azuretest/modules/cdn/module.ftl
+++ b/azuretest/modules/cdn/module.ftl
@@ -15,37 +15,32 @@
             "Tiers" : {
                 "web" : {
                     "Components" : {
-                        "cdn" : {
-                            "cdn" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "solution-az-cdn-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "Certificate": {
-                                    "Host" : "mawk"
-                                },
-                                "WAF": {
-                                    "OWASP" : true
-                                },
-                                "Routes" : {}
-                            }
+                        "cdnbase" : {
+                            "Type": "cdn",
+                            "deployment:Unit": "azure-cdn",
+                            "Profiles" : {
+                                "Testing" : [ "cdnbase" ]
+                            },
+                            "Certificate": {
+                                "Host" : "mawk"
+                            },
+                            "WAF": {
+                                "OWASP" : true
+                            },
+                            "Routes" : {}
                         }
                     }
                 }
             },
             "TestCases" : {
-                "basecdntemplate" : {
+                "cdnbase" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "FrontDoorID" : {
-                                    "Path" : "outputs.frontdoorXwebXcdn.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Path" : "outputs.frontdoorXwebXcdnbase.value",
+                                    "Value" : "[resourceId('Microsoft.Network/frontDoors', 'mockedup-integration-web-cdnbase-568132487')]"
                                 }
                             }
                         }
@@ -53,9 +48,9 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "cdnbase" : {
                     "cdn" : {
-                        "TestCases" : [ "basecdntemplate" ]
+                        "TestCases" : [ "cdnbase" ]
                     }
                 }
             }

--- a/azuretest/modules/computecluster/module.ftl
+++ b/azuretest/modules/computecluster/module.ftl
@@ -14,7 +14,7 @@
             {
                 "Type" : "Builds",
                 "Scope" : "Products",
-                "Namespace" : "mockedup-integration-application-az-computecluster-base",
+                "Namespace" : "mockedup-integration-app-computeclusterbase",
                 "Settings" : {
                     "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE
                 }
@@ -22,7 +22,7 @@
             {
                 "Type" : "Settings",
                 "Scope" : "Products",
-                "Namespace" : "mockedup-integration-application-az-computecluster-base",
+                "Namespace" : "mockedup-integration-app-computeclusterbase",
                 "Settings" : {
                     "Master" : {
                         "Username" : "bojangles"
@@ -34,57 +34,52 @@
             "Tiers" : {
                 "app" : {
                     "Components" : {
-                        "computecluster" : {
-                            "computecluster" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "application-az-computecluster-base" ]
-                                    }
+                        "computeclusterbase" : {
+                            "Type": "computecluster",
+                            "deployment:Unit": "azure-computecluster",
+                            "Profiles" : {
+                                "Testing" : [ "computeclusterbase" ]
+                            },
+                            "Ports" : {
+                                "http" : {
+                                    "IPAddressGroups" : ["_global"]
                                 },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "Ports" : {
-                                    "http" : {
-                                        "IPAddressGroups" : ["_global"]
-                                    },
-                                    "https" : {
-                                        "IPAddressGroups" : ["_global"]
-                                    }
-                                },
-                                "DockerHost" : true,
-                                "azure:ScalingProfiles" : {
-                                    "default" : {
-                                        "MinCapacity" : 1,
-                                        "MaxCapacity" : 2,
-                                        "DefaultCapacity" : 1,
-                                        "ScalingRules" : {
-                                            "workerUp" : {
-                                                "MetricName" : "CpuPercentage",
-                                                "TimeGrain" : "PT1M",
-                                                "Statistic" : "Average",
-                                                "TimeWindow" : "PT5M",
-                                                "TimeAggregation" : "Average",
-                                                "Operator" : "GreaterThan",
-                                                "Threshold" : 50,
-                                                "Direction" : "Increase",
-                                                "ActionType" : "ChangeCount",
-                                                "Cooldown" : "PT5M",
-                                                "ActionValue" : 1
-                                            },
-                                            "workerDown" : {
-                                                "MetricName" : "CpuPercentage",
-                                                "TimeGrain" : "PT1M",
-                                                "Statistic" : "Average",
-                                                "TimeWindow" : "PT5M",
-                                                "TimeAggregation" : "Average",
-                                                "Operator" : "LessThan",
-                                                "Threshold" : 30,
-                                                "Direction" : "Decrease",
-                                                "ActionType" : "ChangeCount",
-                                                "Cooldown" : "PT5M",
-                                                "ActionValue" : 1
-                                            }
+                                "https" : {
+                                    "IPAddressGroups" : ["_global"]
+                                }
+                            },
+                            "DockerHost" : true,
+                            "azure:ScalingProfiles" : {
+                                "default" : {
+                                    "MinCapacity" : 1,
+                                    "MaxCapacity" : 2,
+                                    "DefaultCapacity" : 1,
+                                    "ScalingRules" : {
+                                        "workerUp" : {
+                                            "MetricName" : "CpuPercentage",
+                                            "TimeGrain" : "PT1M",
+                                            "Statistic" : "Average",
+                                            "TimeWindow" : "PT5M",
+                                            "TimeAggregation" : "Average",
+                                            "Operator" : "GreaterThan",
+                                            "Threshold" : 50,
+                                            "Direction" : "Increase",
+                                            "ActionType" : "ChangeCount",
+                                            "Cooldown" : "PT5M",
+                                            "ActionValue" : 1
+                                        },
+                                        "workerDown" : {
+                                            "MetricName" : "CpuPercentage",
+                                            "TimeGrain" : "PT1M",
+                                            "Statistic" : "Average",
+                                            "TimeWindow" : "PT5M",
+                                            "TimeAggregation" : "Average",
+                                            "Operator" : "LessThan",
+                                            "Threshold" : 30,
+                                            "Direction" : "Decrease",
+                                            "ActionType" : "ChangeCount",
+                                            "Cooldown" : "PT5M",
+                                            "ActionValue" : 1
                                         }
                                     }
                                 }
@@ -94,14 +89,14 @@
                 }
             },
             "TestCases" : {
-                "basecomputeclustertemplate" : {
+                "computeclusterbase" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "ScaleSetID" : {
-                                    "Path" : "outputs.vmssXsettingsXappXcomputecluster.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Path" : "outputs.vmssXsettingsXappXcomputeclusterbase.value",
+                                    "Value" : "[resourceId('Microsoft.Compute/virtualMachineScaleSets', 'app-computeclusterbase')]"
                                 }
                             }
                         }
@@ -109,9 +104,9 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "computeclusterbase" : {
                     "computecluster" : {
-                        "TestCases" : [ "basecomputeclustertemplate" ]
+                        "TestCases" : [ "computeclusterbase" ]
                     }
                 }
             }

--- a/azuretest/modules/db/module.ftl
+++ b/azuretest/modules/db/module.ftl
@@ -15,81 +15,71 @@
             "Tiers" : {
                 "db" : {
                     "Components" : {
-                        "database" : {
-                            "db" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "solution-az-db-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "postgrestest" ]
-                                },
-                                "DatabaseName" : "mockdb",
-                                "Engine" : "postgres",
-                                "EngineVersion" : "11",
-                                "Port" : "postgresql",
-                                "GenerateCredentials" : {
-                                    "Enabled" : true,
-                                    "MasterUserName" : "mockuser",
-                                    "CharacterLength" : 20
-                                },
-                                "Size" : 20,
-                                "azure:SecretSettings": {
-                                    "Prefix": "MOCK"
-                                }
+                        "dbbase_postgres" : {
+                            "Type": "db",
+                            "deployment:Unit": "azure-db",
+                            "Profiles" : {
+                                "Testing" : [ "dbbase_postgres" ]
+                            },
+                            "DatabaseName" : "mockdb",
+                            "Engine" : "postgres",
+                            "EngineVersion" : "11",
+                            "Port" : "postgresql",
+                            "GenerateCredentials" : {
+                                "Enabled" : true,
+                                "MasterUserName" : "mockuser",
+                                "CharacterLength" : 20
+                            },
+                            "Size" : 20,
+                            "azure:SecretSettings": {
+                                "Prefix": "MOCK"
                             }
                         },
-                        "mysqldb" : {
-                            "db" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "solution-az-mysqldb" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "mysqltest" ]
-                                },
-                                "DatabaseName" : "mockdb",
-                                "Engine" : "mysql",
-                                "EngineVersion" : "5.7",
-                                "Port" : "mysql",
-                                "GenerateCredentials" : {
-                                    "Enabled" : true,
-                                    "MasterUserName" : "mockuser",
-                                    "CharacterLength" : 20
-                                },
-                                "Size" : 20,
-                                "azure:SecretSettings": {
-                                    "Prefix": "MOCK"
-                                }
+                        "dbbase_mysql" : {
+                            "Type": "db",
+                            "deployment:Unit": "azure-db",
+                            "Profiles" : {
+                                "Testing" : [ "dbbase_mysql" ]
+                            },
+                            "DatabaseName" : "mockdb",
+                            "Engine" : "mysql",
+                            "EngineVersion" : "5.7",
+                            "Port" : "mysql",
+                            "GenerateCredentials" : {
+                                "Enabled" : true,
+                                "MasterUserName" : "mockuser",
+                                "CharacterLength" : 20
+                            },
+                            "Size" : 20,
+                            "azure:SecretSettings": {
+                                "Prefix": "MOCK"
                             }
                         }
                     }
                 }
             },
             "TestCases" : {
-                "basedbtemplate" : {
+                "dbbase_postgres" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "DatabaseID" : {
-                                    "Path" : "outputs.postgresserverXdbXdatabaseXurl.value",
-                                    "Value" : "https://mock.local/postgresserverXdbXdatabaseXurl"
+                                    "Path" : "outputs.postgresserverXdbXdbbaseXpostgresXurl.value",
+                                    "Value" : "[reference(resourceId('Microsoft.DBforPostgreSQL/servers', 'postgresserver-db-dbbase_postgres-568132487'), '2017-12-01', 'Full').properties.fullyQualifiedDomainName]"
                                 }
                             }
                         }
                     }
                 },
-                "mysqldbtemplate" : {
+                "dbbase_mysql" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "DatabaseID" : {
-                                    "Path" : "outputs.mysqlserverXdbXmysqldbXurl.value",
-                                    "Value" : "https://mock.local/mysqlserverXdbXmysqldbXurl"
+                                    "Path" : "outputs.mysqlserverXdbXdbbaseXmysqlXurl.value",
+                                    "Value" : "[reference(resourceId('Microsoft.DBforMySQL/servers', 'mysqlserver-db-dbbase_mysql-568132487'), '2017-12-01', 'Full').properties.fullyQualifiedDomainName]"
                                 }
                             }
                         }
@@ -97,14 +87,14 @@
                 }
             },
             "TestProfiles" : {
-                "postgrestest" : {
+                "dbbase_postgres" : {
                     "db" : {
-                        "TestCases" : [ "basedbtemplate" ]
+                        "TestCases" : [ "dbbase_postgres" ]
                     }
                 },
-                "mysqltest" : {
+                "dbbase_mysql" : {
                     "db" : {
-                        "TestCases" : [ "mysqldbtemplate" ]
+                        "TestCases" : [ "dbbase_mysql" ]
                     }
                 }
             }

--- a/azuretest/modules/gateway/module.ftl
+++ b/azuretest/modules/gateway/module.ftl
@@ -14,26 +14,69 @@
         settingSets=[]
         blueprint={
             "Tiers" : {
-                "mgmt" : {
+                "GatewaySubnet" : {
+                    "Network": {
+                        "Enabled": true,
+                        "Link": {
+                            "Tier": "GatewaySubnet",
+                            "Component": "gatewaybase_private_network"
+                        },
+                        "NetworkACL" : "_none",
+                        "RouteTable" : "default"
+                    },
                     "Components" : {
-                        "gateway" : {
-                            "gateway" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "azure-gateway-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "Engine" : "vpcendpoint"
+                        "gatewaybase_private" : {
+                            "Type": "gateway",
+                            "deployment:Unit": "azure-gateway",
+                            "Profiles" :{
+                                "Testing": ["gatewaybase_private"]
+                            },
+                            "Engine" : "private",
+                            "Destinations": {
+                                "dst": {
+
+                                }
+                            }
+                        },
+                        "gatewaybase_private_network": {
+                            "Type": "network",
+                            "deployment:Unit": "azure-gateway",
+                            "RouteTables" : {
+                                "default": {}
+                            },
+                            "NetworkACLs": {
+                                "_none": {}
                             }
                         }
                     }
                 }
             },
-            "TestCases" : {},
-            "TestProfiles" : {}
+            "TestCases" : {
+                "gatewaybase_private": {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "JSON" : {
+                            "Match" : {
+                                "gatewayVnet" : {
+                                    "Path" : "outputs.vnetXGatewaySubnetXgatewaybaseXprivateXnetwork.value",
+                                    "Value" : "[resourceId('Microsoft.Network/virtualNetworks', 'mockedup-int-GatewaySubnet-gatewaybase_private_network-network')]"
+                                },
+                                "networkGateway": {
+                                    "Path": "outputs.virtualNetworkGWXGatewaySubnetXgatewaybaseXprivateXgateway.value",
+                                    "Value": "[resourceId('Microsoft.Network/virtualNetworkGateways', 'virtualNetworkGW-GatewaySubnet-gatewaybase_private-gateway')]"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "gatewaybase_private": {
+                    "gateway": {
+                        "TestCases": ["gatewaybase_private"]
+                    }
+                }
+            }
         }
         stackOutputs=[]
         commandLineOption={}

--- a/azuretest/modules/lambda/module.ftl
+++ b/azuretest/modules/lambda/module.ftl
@@ -15,7 +15,7 @@
             {
                 "Type" : "Builds",
                 "Scope" : "Products",
-                "Namespace" : "mockedup-integration-app-lambda-api",
+                "Namespace" : "mockedup-integration-app-lambda",
                 "Settings" : {
                     "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
                     "FORMATS" : ["lambda"]
@@ -26,18 +26,16 @@
             "Tiers" : {
                 "app" : {
                     "Components" : {
-                        "lambda" : {
+                        "lambdabase" : {
                             "Type" : "lambda",
-                            "deployment:Unit" : "application-az-lambda-base",
+                            "deployment:Unit" : "azure-lambda",
                             "Profiles" : {
-                                "Testing" : [ "baselambdatemplate" ]
+                                "Testing" : [ "lambdabase" ]
                             },
                             "Functions" : {
                                 "api" : {
                                     "Handler" : "src/handler.api",
-                                    "RunTime" : "nodejs14.x",
-                                    "Extensions" : [ "_mockext" ],
-                                    "Links" : {}
+                                    "RunTime" : "nodejs14.x"
                                 }
                             }
                         }
@@ -45,14 +43,14 @@
                 }
             },
             "TestCases" : {
-                "baselambdatemplate" : {
+                "lambdabase" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "AppServicePlanID" : {
-                                    "Path" : "outputs.sitesXappXlambdaXapi.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Path" : "outputs.sitesXappXlambdabaseXapi.value",
+                                    "Value" : "[resourceId('Microsoft.Web/sites', 'mockedup-int-app-lambdabase-api-568132487')]"
                                 }
                             }
                         }
@@ -60,9 +58,9 @@
                 }
             },
             "TestProfiles" : {
-                "baselambdatemplate" : {
-                    "lambda" : {
-                        "TestCases" : [ "baselambdatemplate" ]
+                "lambdabase" : {
+                    "function" : {
+                        "TestCases" : [ "lambdabase" ]
                     }
                 }
             }

--- a/azuretest/modules/lb/module.ftl
+++ b/azuretest/modules/lb/module.ftl
@@ -15,36 +15,29 @@
             "Tiers" : {
                 "elb" : {
                     "Components" : {
-                        "lb" : {
-                            "lb" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "solution-az-lb-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "Engine" : "application",
-                                "Ports" : {
-                                    "testport" : {
-                                        "Enabled" : true
-                                    }
-                                }
+                        "lbbase" : {
+                            "Type": "lb",
+                            "deployment:Unit": "azure-lb",
+                            "Profiles" : {
+                                "Testing" : [ "lbbase" ]
+                            },
+                            "Engine" : "application",
+                            "Ports" : {
+                                "testport" : {}
                             }
                         }
                     }
                 }
             },
             "TestCases" : {
-                "baselbtemplate" : {
+                "lbbase" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "AppGatewayID" : {
-                                    "Path" : "outputs.appGatewayXmockedupXintegrationXelbXlb.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Path" : "outputs.appGatewayXmockedupXintegrationXelbXlbbase.value",
+                                    "Value" : "[resourceId('Microsoft.Network/applicationGateways', 'appGateway-mockedup-integration-elb-lbbase')]"
                                 }
                             }
                         }
@@ -52,9 +45,9 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "lbbase" : {
                     "lb" : {
-                        "TestCases" : [ "baselbtemplate" ]
+                        "TestCases" : [ "lbbase" ]
                     }
                 }
             }

--- a/azuretest/modules/network/module.ftl
+++ b/azuretest/modules/network/module.ftl
@@ -36,8 +36,7 @@
                                             "Link" : {
                                                 "Tier": "mgmt",
                                                 "Component": "baseline",
-                                                "SubComponent": "opsdata",
-                                                "Type": "baselinedata"
+                                                "Type": "baseline"
                                             }
                                         }
                                     }

--- a/azuretest/modules/network/module.ftl
+++ b/azuretest/modules/network/module.ftl
@@ -31,7 +31,15 @@
                                 "FlowLogs" : {
                                     "default" : {
                                         "Action" : "accept",
-                                        "Enabled" : true
+                                        "Enabled" : true,
+                                        "s3" : {
+                                            "Link" : {
+                                                "Tier": "mgmt",
+                                                "Component": "baseline",
+                                                "SubComponent": "opsdata",
+                                                "Type": "baselinedata"
+                                            }
+                                        }
                                     }
                                 }
                             },

--- a/azuretest/modules/network/module.ftl
+++ b/azuretest/modules/network/module.ftl
@@ -15,65 +15,60 @@
             "Tiers" : {
                 "mgmt" : {
                     "Components" : {
-                        "vnet" : {
-                            "network" : {
-                                "Instances" : {
+                        "networkbase" : {
+                            "Type": "network",
+                            "deployment:Unit": "azure-network",
+                            "Profiles" : {
+                                "Testing" : [ "networkbase" ]
+                            },
+                            "RouteTables": {
+                                "internal": {},
+                                "external": {
+                                    "Public": true
+                                }
+                            },
+                            "Logging" : {
+                                "FlowLogs" : {
                                     "default" : {
-                                        "DeploymentUnits" : [ "segment-az-network-base" ]
+                                        "Action" : "accept",
+                                        "Enabled" : true
                                     }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "RouteTables": {
-                                    "internal": {},
-                                    "external": {
-                                        "Public": true
-                                    }
-                                },
-                                "Logging" : {
-                                    "FlowLogs" : {
-                                        "default" : {
-                                            "Action" : "accept",
-                                            "Enabled" : true
-                                        }
-                                    }
-                                },
-                                "NetworkACLs": {
-                                    "open": {
-                                        "Rules": {
-                                            "in": {
-                                                "Priority": 200,
-                                                "Action": "allow",
-                                                "Source": {
-                                                    "IPAddressGroups": [
-                                                        "_global"
-                                                    ]
-                                                },
-                                                "Destination": {
-                                                    "IPAddressGroups": [
-                                                        "_localnet"
-                                                    ],
-                                                    "Port": "any"
-                                                },
-                                                "ReturnTraffic": false
+                                }
+                            },
+                            "NetworkACLs": {
+                                "open": {
+                                    "Rules": {
+                                        "in": {
+                                            "Priority": 200,
+                                            "Action": "allow",
+                                            "Source": {
+                                                "IPAddressGroups": [
+                                                    "_global"
+                                                ]
                                             },
-                                            "out": {
-                                                "Priority": 200,
-                                                "Action": "allow",
-                                                "Source": {
-                                                    "IPAddressGroups": [
-                                                        "_localnet"
-                                                    ]
-                                                },
-                                                "Destination": {
-                                                    "IPAddressGroups": [
-                                                        "_global"
-                                                    ],
-                                                    "Port": "any"
-                                                },
-                                                "ReturnTraffic": false
-                                            }
+                                            "Destination": {
+                                                "IPAddressGroups": [
+                                                    "_localnet"
+                                                ],
+                                                "Port": "any"
+                                            },
+                                            "ReturnTraffic": false
+                                        },
+                                        "out": {
+                                            "Priority": 200,
+                                            "Action": "allow",
+                                            "Source": {
+                                                "IPAddressGroups": [
+                                                    "_localnet"
+                                                ]
+                                            },
+                                            "Destination": {
+                                                "IPAddressGroups": [
+                                                    "_global"
+                                                ],
+                                                "Port": "any"
+                                            },
+                                            "ReturnTraffic": false
                                         }
                                     }
                                 }
@@ -83,14 +78,14 @@
                 }
             },
             "TestCases" : {
-                "basenetworktemplate" : {
+                "networkbase" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "VNetID" : {
-                                    "Path" : "outputs.vnetXmgmtXvnet.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Path" : "outputs.vnetXmgmtXnetworkbase.value",
+                                    "Value" : "[resourceId('Microsoft.Network/virtualNetworks', 'mockedup-int-mgmt-networkbase-network')]"
                                 }
                             }
                         }
@@ -98,9 +93,9 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "networkbase" : {
                     "network" : {
-                        "TestCases" : [ "basenetworktemplate" ]
+                        "TestCases" : [ "networkbase" ]
                     }
                 }
             }

--- a/azuretest/modules/s3/module.ftl
+++ b/azuretest/modules/s3/module.ftl
@@ -15,38 +15,33 @@
             "Tiers" : {
                 "app" : {
                     "Components" : {
-                        "stage" : {
-                            "S3" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "solution-az-s3-base" ]
-                                    }
-                                },
-                                "Lifecycle" : {
-                                    "Versioning" : true
-                                },
-                                "PublicAccess" : {
-                                    "default" : {
-                                        "IPAddressGroups" : [ "_localnet" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
+                        "s3base" : {
+                            "Type": "s3",
+                            "deployment:Unit": "azure-s3",
+                            "Lifecycle" : {
+                                "Versioning" : true
+                            },
+                            "PublicAccess" : {
+                                "default" : {
+                                    "IPAddressGroups" : [ "_localnet" ]
                                 }
+                            },
+                            "Profiles" : {
+                                "Testing" : [ "s3base" ]
                             }
                         }
                     }
                 }
             },
             "TestCases" : {
-                "bases3template" : {
+                "s3base" : {
                     "OutputSuffix" : "template.json",
                     "Structural" : {
                         "JSON" : {
                             "Match" : {
                                 "StorageID" : {
-                                    "Path" : "outputs.storageXappXstage.value",
-                                    "Value" : AZURE_RESOURCE_ID_MOCK_VALUE
+                                    "Path" : "outputs.storageXappXs3base.value",
+                                    "Value" : "[resourceId('Microsoft.Storage/storageAccounts', 'apps3base568132487')]"
                                 }
                             }
                         }
@@ -54,9 +49,9 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "s3base" : {
                     "s3" : {
-                        "TestCases" : [ "bases3template" ]
+                        "TestCases" : [ "s3base" ]
                     }
                 }
             }

--- a/azuretest/modules/segment/module.ftl
+++ b/azuretest/modules/segment/module.ftl
@@ -1,0 +1,56 @@
+[#ftl]
+
+[@addModule
+    name="segment"
+    description="Standard segment level outputs for higher level components"
+    provider=AZURETEST_PROVIDER
+    properties=[]
+/]
+
+[#macro azuretest_module_segment ]
+
+    [@loadModule
+        settingSets=[]
+        blueprint={}
+        stackOutputs=[
+            {
+                "Account": AZURE_SUBSCRIPTION_MOCK_VALUE,
+                "Region": AZURE_REGION_MOCK_VALUE,
+                "DeploymentUnit": "baseline",
+
+                "seedXsegment": "568132487",
+
+                "keyXcmk": "cmk-123-def-456",
+                "secretXssh": "ssh-123-def-456",
+
+
+                "containerXmgmtXbaselineXopsdata": "/subscriptions/${AZURE_SUBSCRIPTION_MOCK_VALUE}/resourceGroups/office-production-directory-seg-baseline/providers/Microsoft.Storage/storageAccounts/mgmtbaseline107091004910/blobServices/default/containers/opsdata",
+                "containerXmgmtXbaselineXappdata": "/subscriptions/${AZURE_SUBSCRIPTION_MOCK_VALUE}/resourceGroups/office-production-directory-seg-baseline/providers/Microsoft.Storage/storageAccounts/mgmtbaseline107091004910/blobServices/default/containers/appdata",
+                "storageXmgmtXbaseline": "/subscriptions/${AZURE_SUBSCRIPTION_MOCK_VALUE}/resourceGroups/office-production-directory-seg-baseline/providers/Microsoft.Storage/storageAccounts/mgmtbaseline107091004910"
+            },
+            {
+                "Account": AZURE_SUBSCRIPTION_MOCK_VALUE,
+                "Region": AZURE_REGION_MOCK_VALUE,
+                "DeploymentUnit": "vpc",
+
+                "vnetXmgmtXvpc": "vnet123",
+
+                "subnetsXmgmt": "subnetmgmt",
+                "subnetsXdir": "subnetdir",
+                "subnetsXweb": "subnetweb",
+                "subnetsXdb": "subnetdb",
+                "subnetsXapp": "subnetapp",
+                "subnetsXapi": "subnetapi",
+                "subnetsXelb": "subnetelb",
+
+                "nsgXvnetXmgmtXvpcXmgmtXvpcXPublic": "nsgPublic",
+                "nsgXvnetXmgmtXvpcXmgmtXvpcXPrivate": "nsgPrivate",
+                "nsgXvnetXmgmtXvpcXmgmtXvpcXLBPrivate": "nsgPrivate",
+                "nsgXvnetXmgmtXvpcXmgmtXvpcXLBPublic": "nsgLBPublic",
+                "nsgXvnetXmgmtXvpcXmgmtXvpcXDirectoryPrivate": "nsgDirectoryPrivate"
+            }
+        ]
+        commandLineOption={}
+    /]
+
+[/#macro]

--- a/azuretest/modules/spa/module.ftl
+++ b/azuretest/modules/spa/module.ftl
@@ -14,7 +14,7 @@
             {
                 "Type" : "Builds",
                 "Scope" : "Products",
-                "Namespace" : "mockedup-integration-application-az-spa-base",
+                "Namespace" : "mockedup-integration-app-spabase",
                 "Settings" : {
                     "COMMIT" : AZURE_BUILD_COMMIT_MOCK_VALUE,
                     "FORMATS" : ["spa"]
@@ -25,23 +25,18 @@
             "Tiers" : {
                 "app" : {
                     "Components" : {
-                        "spa" : {
-                            "spa" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "application-az-spa-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                }
+                        "spabase" : {
+                            "Type": "spa",
+                            "deployment:Unit": "azure-spa",
+                            "Profiles" : {
+                                "Testing" : [ "spabase" ]
                             }
                         }
                     }
                 }
             },
             "TestCases" : {
-                "basespatemplate" : {
+                "spabase" : {
                     "OutputSuffix" : "config.json",
                     "Structural" : {
                         "JSON" : {
@@ -53,9 +48,9 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "spabase" : {
                     "spa" : {
-                        "TestCases" : [ "basespatemplate" ]
+                        "TestCases" : [ "spabase" ]
                     }
                 }
             }

--- a/azuretest/modules/sqs/module.ftl
+++ b/azuretest/modules/sqs/module.ftl
@@ -9,29 +9,20 @@
 
 [#macro azuretest_module_sqs ]
 
+    [#--TODO(roleyfoley): add tests for bash script --]
     [@loadModule
         settingSets=[]
         blueprint={
             "Tiers" : {
                 "app" : {
                     "Components" : {
-                        "sqs" : {
-                            "sqs" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "solution-az-sqs-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                }
-                            }
+                        "sqsbase" : {
+                            "Type": "sqs",
+                            "deployment:Unit": "azure-sqs"
                         }
                     }
                 }
-            },
-            "TestCases" : {},
-            "TestProfiles" : {}
+            }
         }
         stackOutputs=[]
         commandLineOption={}

--- a/azuretest/modules/userpool/module.ftl
+++ b/azuretest/modules/userpool/module.ftl
@@ -15,17 +15,9 @@
             "Tiers" : {
                 "dir" : {
                     "Components" : {
-                        "userpool" : {
-                            "userpool" : {
-                                "Instances" : {
-                                    "default" : {
-                                        "DeploymentUnits" : [ "solution-az-userpool-base" ]
-                                    }
-                                },
-                                "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                }
-                            }
+                        "userpoolbase" : {
+                            "Type": "userpool",
+                            "deployment:Unit": "azure-userpool"
                         }
                     }
                 }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Removes the mock output service to allow for referencing between resources to behave as intended
- Consolidate deployment units to components to reduce testing time
- Align configuration with latest configuration options

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The intention with this change is to make sure that template content is generated as expected and doesn't rely on faked reference values and instead assumes that resources aren't all deployed

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

