### PR TITLE
feat(network): manage vpn cipher configuration

### DIFF
--- a/azure/services/microsoft.network/resource.ftl
+++ b/azure/services/microsoft.network/resource.ftl
@@ -820,12 +820,48 @@
   ipsecEncryption
   ipsecIntegrity
   saLifeTimeSeconds
-  pfsGroup=""
   saDataSizeKilobytes=""]
 
-  [#if dhGroup?is_number ]
-    [#local dhGroup = "DHGroup${dhGroup}" ]
-  [/#if]
+  [#local pfsGroup=""]
+  [#switch dhGroup ]
+    [#case 1]
+      [#local dhGroup = "DHGroup1"]
+      [#local pfsGroup = "PFS1"]
+      [#break]
+
+    [#case 2]
+      [#local dhGroup = "DHGroup2"]
+      [#local pfsGroup = "PFS2"]
+      [#break]
+
+    [#case 14]
+      [#local dhGroup = "DHGroup14"]
+      [#break]
+
+    [#case 19]
+      [#local dhGroup = "ECP256"]
+      [#local pfsGroup = "ECP256"]
+      [#break]
+
+    [#case 20]
+      [#local dhGroup = "ECP384"]
+      [#local pfsGroup = "ECP384"]
+      [#break]
+
+    [#case 24]
+      [#local dhGroup = "DHGroup24"]
+      [#local pfsGroup = "PFS24"]
+      [#break]
+
+    [#default]
+      [@fatal
+        message="Unsupported DH Group for IPSec Policy"
+        context={
+          "SupportedGroups" : [ 1, 2, 14, 19, 20, 21, 24]
+        }
+
+      /]
+  [/#switch]
 
   [#return
       {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Creates standard definitions of the vpn ipsec ciphers used for virtual network gateways based on group number based standard

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When configuring the VPN ipsec cipher suite using just the group number would only map to the cipher spec and didn't include the PFS configuration. To standardise the approach and use PFS as a standard security standard we now map the number group numbers to PFS and cipher suite groups

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and on VPN between AWS and Azure. 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

