### PR TITLE
fix: remove use of getRegistryPrefix and EndPoint

### DIFF
--- a/azure/components/adaptor/setup.ftl
+++ b/azure/components/adaptor/setup.ftl
@@ -14,14 +14,6 @@
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData" ] )]
 
-    [#local codeSrcBucket = getRegistryEndPoint("scripts", occurrence)]
-    [#local codeSrcPrefix = formatRelativePath(
-                                getRegistryPrefix("scripts", occurrence),
-                                    productName,
-                                    getOccurrenceBuildScopeExtension(occurrence),
-                                    getOccurrenceBuildUnit(occurrence),
-                                    getOccurrenceBuildReference(occurrence))]
-
     [#local buildSettings = occurrence.Configuration.Settings.Build]
     [#local buildRegistry = buildSettings["BUILD_FORMATS"].Value[0]]
 

--- a/azure/components/computecluster/setup.ftl
+++ b/azure/components/computecluster/setup.ftl
@@ -45,7 +45,7 @@
                 "Id" : storageAccountId,
                 "Name" : storageName
             },
-            "Container" : getRegistryPrefix("scripts", occurrence)?remove_ending("/"),
+            "Container" : getOccurrenceSettingValue(occurrence, ["Registries", "scripts", "Prefix"], true)?remove_ending("/"),
             "BlobName" : core.ShortName + ".zip",
             "BlobPath" : formatRelativePath(
                             productName,

--- a/azure/services/microsoft.storage/resource.ftl
+++ b/azure/services/microsoft.storage/resource.ftl
@@ -254,8 +254,8 @@
     [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData"], false, false)]
     [#local storageAccount = baselineLinks["OpsData"].State.Attributes["ACCOUNT_NAME"]]
 
-    [#local container = getRegistryPrefix(registry, occurrence)?remove_ending("/")]
-    [#local fileName = getRegistryPrefix(registry, occurrence)?remove_ending("/")?ensure_ends_with(".zip") ]
+    [#local container = getOccurrenceSettingValue(occurrence, ["Registries", registry, "Prefix"], true)?remove_ending("/")]
+    [#local fileName = getOccurrenceSettingValue(occurrence, ["Registries", registry, "Prefix"], true)?remove_ending("/")?ensure_ends_with(".zip") ]
     [#local path = formatRelativePath(
         product,
         getOccurrenceBuildScopeExtension(occurrence),


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Replace/remove getRegistryPrefix and getRegistryEndPoint calls

It would be useful if someone that understands the motivation behind the change in location identification could check this is consistent with the reason for the removal of getRegistryPrefix and getRegistryEndPoint

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Current failures in Azure plugin causes tram and train hamlet builds to fail

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally run test suite to ensure AWS tram and train can be built

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

