### PR TITLE
fix(computecluster): bootstraps lookup from global

### DIFF
--- a/azure/components/computecluster/setup.ftl
+++ b/azure/components/computecluster/setup.ftl
@@ -388,6 +388,7 @@
     [#local extProtectedSettings = {}]
     [#local commandsToExecute = []]
     [#local bootstrapProfile = getBootstrapProfile(occurrence, core.Type)]
+    [#local bootstraps = getReferenceData(BOOTSTRAP_REFERENCE_TYPE, true) ]
 
     [#if (bootstrapProfile.Bootstraps)??]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Removes the bootstraps global variable lookup and replaces it with a locally defined reference to the boostraps

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Generation of computercluster templates failing

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested with test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

